### PR TITLE
user functional indexes on username and email

### DIFF
--- a/db/migrate/20200510165932_add_case_insensitive_indexes_to_username_and_email_on_users.rb
+++ b/db/migrate/20200510165932_add_case_insensitive_indexes_to_username_and_email_on_users.rb
@@ -1,0 +1,17 @@
+class AddCaseInsensitiveIndexesToUsernameAndEmailOnUsers < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :users, :email
+    remove_index :users, :username
+
+    add_index :users, "LOWER(email)", unique: true, name: "index_users_on_LOWER_email"
+    add_index :users, "LOWER(username)", unique: true, name: "index_users_on_LOWER_username"
+  end
+
+  def down
+    remove_index :users, name: "index_users_on_LOWER_email"
+    remove_index :users, name: "index_users_on_LOWER_username"
+
+    add_index :users, "email", unique: true
+    add_index :users, "username", unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_09_060917) do
+ActiveRecord::Schema.define(version: 2020_05_10_165932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,12 +32,12 @@ ActiveRecord::Schema.define(version: 2020_05_09_060917) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "role", default: 0, null: false
     t.text "username", null: false
+    t.index "lower(email)", name: "index_users_on_LOWER_email", unique: true
+    t.index "lower(username)", name: "index_users_on_LOWER_username", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role"], name: "index_users_on_role"
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end


### PR DESCRIPTION
This commit updates the indexes on `username` and
  `email` on the `users` table to be functional indexes
  that user the `LOWER` function to allow for case-insensitive
  exact matches.

We could have used `citext` for this, but that is postgres-specific,
  and there is desire amongst the community to be able to port the
  application to other DBMSs in the future without huge issues (I
  realize that it will still be a pain in the ass, but I'll do what I
  can to support this regardless).