### PR TITLE
don't add text datatype by default

### DIFF
--- a/db/migrate/20200509055128_devise_create_users.rb
+++ b/db/migrate/20200509055128_devise_create_users.rb
@@ -4,11 +4,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.text :email,              null: false, default: ""
-      t.text :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
-      t.text   :reset_password_token
+      t.string   :reset_password_token
       t.datetime :reset_password_sent_at
 
       ## Rememberable
@@ -22,14 +22,14 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       # t.inet     :last_sign_in_ip
 
       ## Confirmable
-      t.text   :confirmation_token
+      t.string   :confirmation_token
       t.datetime :confirmed_at
       t.datetime :confirmation_sent_at
-      t.text   :unconfirmed_email # Only if using reconfirmable
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
-      t.text   :unlock_token # Only if unlock strategy is :email or :both
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
       t.datetime :locked_at
 
 

--- a/db/migrate/20200509060917_add_username_to_users.rb
+++ b/db/migrate/20200509060917_add_username_to_users.rb
@@ -1,6 +1,6 @@
 class AddUsernameToUsers < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :username, :text, null: false
+    add_column :users, :username, :string, null: false, limit: 20
     add_index :users, :username, unique: true
   end
 end

--- a/db/migrate/20200510165932_add_case_insensitive_indexes_to_username_and_email_on_users.rb
+++ b/db/migrate/20200510165932_add_case_insensitive_indexes_to_username_and_email_on_users.rb
@@ -11,7 +11,7 @@ class AddCaseInsensitiveIndexesToUsernameAndEmailOnUsers < ActiveRecord::Migrati
     remove_index :users, name: "index_users_on_LOWER_email"
     remove_index :users, name: "index_users_on_LOWER_username"
 
-    add_index :users, "email", unique: true
-    add_index :users, "username", unique: true
+    add_index :users, :email, unique: true
+    add_index :users, :username, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,24 +16,24 @@ ActiveRecord::Schema.define(version: 2020_05_10_165932) do
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.text "email", default: "", null: false
-    t.text "encrypted_password", default: "", null: false
-    t.text "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.text "confirmation_token"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.text "unconfirmed_email"
+    t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
-    t.text "unlock_token"
+    t.string "unlock_token"
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "role", default: 0, null: false
-    t.text "username", null: false
-    t.index "lower(email)", name: "index_users_on_LOWER_email", unique: true
-    t.index "lower(username)", name: "index_users_on_LOWER_username", unique: true
+    t.string "username", limit: 20, null: false
+    t.index "lower((email)::text)", name: "index_users_on_LOWER_email", unique: true
+    t.index "lower((username)::text)", name: "index_users_on_LOWER_username", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role"], name: "index_users_on_role"


### PR DESCRIPTION
Since I almost exclusively work with postgres,
  I have a habit of defaulting to the text datatype
  given the way that it is treating by the dbms (I
  won't get into that here).

Since we're aiming to not tie ourselves to a specific
  db implementation, I'm changing this to support that
  goal.

The `text` datatype, then, should only be used for text
  strings that are sufficiently large (i.e. not emails
  and usernames).