### PR TITLE
submissions index / skeleton stuff

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import "bourbon";
 @import "base/base";
 @import "shared/shared";
+@import "pages/pages";

--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -17,12 +17,13 @@ body {
 
 .application-container {
   @include padding(var(--spacing--small));
-  width: 75%;
+  width: 50%;
   margin: auto;
 }
 
-@media only screen and (max-width: 935px) {
+@media only screen and (max-width: 1155px) {
   .application-container {
     margin-top: 175px;
+    width: 60%;
   }
 }

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -1,10 +1,11 @@
 // Colors
 $blue: #1565c0;
 $blue-light: #3b83d5;
-$gray: #333;
-$white: #fff;
 $congress-blue: #004e98;
+$gray: #333;
 $off-indigo: #4f86c6;
+$scorpion: #606060;
+$white: #fff;
 
 // Font Colors
 $font-color--base: $gray;

--- a/app/assets/stylesheets/pages/_pages.scss
+++ b/app/assets/stylesheets/pages/_pages.scss
@@ -1,0 +1,1 @@
+@import "submissions";

--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -1,0 +1,41 @@
+.submissions-list {
+  @include padding(var(--spacing--smaller) null null null);
+
+  ol {
+    li {
+      @include padding(null null var(--spacing--small) null);
+      .submission-line1 {
+        .submission-link a {
+          text-decoration: none;
+          font-size: 1.2rem;
+          font-weight: var(--font-weight--bold);
+          font-color: $primary-color;
+        }
+      }
+      .submission-line2 {
+        .submission-info, .submission-comments {
+          color: $scorpion;
+          a {
+            text-decoration: none;
+            color: $scorpion;
+          }
+        }
+
+        .submission-time::after {
+          content: "|";
+        }
+
+        .submission-info a::after {
+          @include margin(null 1px null null);
+          @include padding(null null null 4px);
+          content: "|";
+          font-size: 1rem;
+        }
+        .submission-user {
+          color: $off-indigo;
+          a { text-decoration: none; }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/_navbar.scss
+++ b/app/assets/stylesheets/shared/_navbar.scss
@@ -6,7 +6,7 @@
   line-height: 55px;
 
   .navbar-elements {
-    width: 75%;
+    width: 50%;
     margin: auto;
 
     .navbar-brand {
@@ -43,7 +43,7 @@
   }
 }
 
-@media only screen and (max-width: 935px) {
+@media only screen and (max-width: 1155px) {
   .navbar {
     padding: 0;
     height: 40px;

--- a/app/assets/stylesheets/shared/_pagination.scss
+++ b/app/assets/stylesheets/shared/_pagination.scss
@@ -1,0 +1,10 @@
+.pagination-controls {
+  @include padding(var(--spacing--small) null var(--spacing--small) null);
+  .pagination-back {
+    margin-right: var(--spacing--small);
+  }
+  .pagination-back > a, .pagination-forward > a {
+    text-decoration: none;
+    color: $congress-blue;
+  }
+}

--- a/app/assets/stylesheets/shared/_shared.scss
+++ b/app/assets/stylesheets/shared/_shared.scss
@@ -1,2 +1,3 @@
 @import "navbar";
 @import "simple_form";
+@import "pagination";

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,4 +1,11 @@
 class SubmissionsController < ApplicationController
   def index
+    @paginator = SubmissionSearch.new(submission_search_params).results_paginator
+  end
+
+  private
+
+  def submission_search_params
+    params.permit(:page, :per_page)
   end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,0 +1,17 @@
+module SubmissionsHelper
+  def submission_href_for(submission)
+    submission.url.presence || submission_path(submission.id)
+  end
+
+  def submitted_by_text(submission)
+    if submission.original_author?
+      t("submissions.submission_list_item.authored_by")
+    else
+      t("submissions.submission_list_item.submitted_by")
+    end
+  end
+
+  def submitted_time_text(submission)
+    "#{time_ago_in_words(submission.created_at)} #{t('submissions.submission_list_item.ago')}"
+  end
+end

--- a/app/search_objects/results_paginator.rb
+++ b/app/search_objects/results_paginator.rb
@@ -1,0 +1,35 @@
+class ResultsPaginator
+  MAX_PER_PAGE = 100
+
+  def initialize(scope, params)
+    @scope = scope
+    @page = [params.fetch(:page).to_i, MAX_PER_PAGE].min
+    @per_page = params.fetch(:per_page)
+    @order = params.fetch(:order, { id: :asc })
+  end
+
+  def results_page
+    scope.
+      order(order).
+      offset(offset).
+      limit(per_page)
+  end
+
+  def max_page
+    (scope.count.to_f / per_page).ceil - 1
+  end
+
+  def offset
+    if page.zero?
+      0
+    else
+      page * per_page
+    end
+  end
+
+  attr_reader :page, :per_page, :order
+
+  private
+
+  attr_reader :scope
+end

--- a/app/search_objects/submission_search.rb
+++ b/app/search_objects/submission_search.rb
@@ -1,0 +1,28 @@
+class SubmissionSearch
+  DEFAULT_PAGE = 0
+  DEFAULT_PER_PAGE = 25
+
+  def initialize(params)
+    @params = params
+  end
+
+  def results_paginator
+    ResultsPaginator.new(scope, pagination_params)
+  end
+
+  private
+
+  attr_reader :params
+
+  def scope
+    Submission.preload(:user).all
+  end
+
+  def pagination_params
+    {
+      page: params.fetch(:page, DEFAULT_PAGE),
+      per_page: params.fetch(:per_page, DEFAULT_PER_PAGE),
+      order: { id: :desc }
+    }
+  end
+end

--- a/app/views/shared/_pagination_controls.html.haml
+++ b/app/views/shared/_pagination_controls.html.haml
@@ -1,0 +1,8 @@
+.pagination-controls
+  - if paginator.page.positive?
+    %span.pagination-back
+      = link_to t(".previous_page"), submissions_path(page: paginator.page - 1)
+
+  - if paginator.page < paginator.max_page
+    %span.pagination-forward
+      = link_to t(".next_page"), submissions_path(page: paginator.page + 1)

--- a/app/views/submissions/_submission_list.html.haml
+++ b/app/views/submissions/_submission_list.html.haml
@@ -1,0 +1,5 @@
+.submissions-list
+  %ol
+    - submissions.each do |s|
+      = render "submission_list_item", submission: s
+

--- a/app/views/submissions/_submission_list_item.html.haml
+++ b/app/views/submissions/_submission_list_item.html.haml
@@ -1,0 +1,16 @@
+%li{ id: "submission_#{submission.id}" }
+  .submission-line1
+    %span.submission-link= link_to(submission.title, submission_href_for(submission))
+  .submission-line2
+    %span.submission-info
+      = submitted_by_text(submission)
+    %span.submission-user
+      = link_to submission.user.username, "#"
+    %span.submission-info
+      %span.submission-time
+        = submitted_time_text(submission)
+    %span.submission-info
+      = link_to t(".hide"), "#"
+      = link_to t(".save"), "#"
+    %span.submission-comments
+      = link_to t(".comments", count: 25), "#"

--- a/app/views/submissions/index.html.haml
+++ b/app/views/submissions/index.html.haml
@@ -1,0 +1,2 @@
+= render "submission_list", submissions: @paginator.results_page
+= render "shared/pagination_controls", paginator: @paginator

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -1,0 +1,5 @@
+en:
+  shared:
+    pagination_controls:
+      next_page: Next Page →
+      previous_page: ← Previous Page

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -1,0 +1,9 @@
+en:
+  submissions:
+    submission_list_item:
+      submitted_by: via 
+      authored_by: authored by
+      ago: ago
+      hide: hide
+      save: save
+      comments: "%{count} comments"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
 
   root to: "submissions#index"
 
-  resources :submissions, only: [:index]
+  resources :submissions, only: [:index, :show]
 end

--- a/db/migrate/20200510221526_add_original_author_to_submissions.rb
+++ b/db/migrate/20200510221526_add_original_author_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddOriginalAuthorToSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :submissions, :original_author, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_10_174437) do
+ActiveRecord::Schema.define(version: 2020_05_10_221526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_05_10_174437) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "original_author", default: false, null: false
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     sequence(:url) { |n| "https://www.somesite#{n}.com/path/to/content" }
     body { nil }
     user
+    original_author { false }
   end
 end

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe NavbarHelper do
+  describe "#users_link_for" do
+    context "when the user is present" do
+      it "is a link to edit the user's profile" do
+        user = create(:user)
+
+        link_text, url = helper.users_link_for(user)
+
+        expect(link_text).to eq(user.username)
+        expect(url).to eq(edit_user_registration_path)
+      end
+    end
+
+    context "when the user is nil" do
+      it "is the signin link" do
+        link_text, url = helper.users_link_for(nil)
+
+        expect(link_text).to eq(t("devise.sessions.new.sign_in"))
+        expect(url).to eq(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,0 +1,55 @@
+module SubmissionsHelper
+  include ActiveSupport::Testing::TimeHelpers
+  describe "#submission_href_for" do
+    context "when the submission has a URL" do
+      it "is the URL" do
+        submission = build(:submission, url: "https://www.foo.com")
+
+        expect(helper.submission_href_for(submission)).to eq("https://www.foo.com")
+      end
+    end
+
+    context "when the submission does not have a URL" do
+      it "is the link to the submission" do
+        submission = create(:submission, url: nil)
+
+        expect(helper.submission_href_for(submission)).to eq(submission_path(submission.id))
+      end
+    end
+  end
+
+  describe "#submitted_by_text" do
+    context "when the user who made the submission is the original author" do
+      it "is the relevant `authored_by` translation" do
+        submission = build(:submission, original_author: true)
+
+        expect(helper.submitted_by_text(submission)).
+          to eq(t("submissions.submission_list_item.authored_by"))
+      end
+    end
+
+    context "when the user who made the submission is not the original author" do
+      it "is the relevant `submitted_by` translation" do
+        submission = build(:submission, original_author: false)
+
+        expect(helper.submitted_by_text(submission)).
+          to eq(t("submissions.submission_list_item.submitted_by"))
+      end
+    end
+  end
+
+  describe "#submitted_time_text" do
+    it "says how long ago the submission was submitted" do
+      travel_to Time.zone.local(2020) do
+        created = 1.hour.ago
+
+        submission = build(:submission, created_at: created)
+
+        expect(helper.submitted_time_text(submission)).to eq(
+          "#{t('datetime.distance_in_words.about_x_hours.one')} "\
+          "#{t('submissions.submission_list_item.ago')}"
+        )
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,8 +37,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-  config.include Warden::Test::Helpers
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
+  config.include Warden::Test::Helpers
 
   config.before(:each, type: :system) do
     driven_by(:rack_test)

--- a/spec/search_objects/results_paginator_spec.rb
+++ b/spec/search_objects/results_paginator_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ResultsPaginator do
+  describe "#results_page" do
+    it "properly offsets and limits the results" do
+      s1, s2, s3 = create_list(:submission, 3)
+
+      expect(ResultsPaginator.new(Submission.all, page: 0, per_page: 3).results_page).to eq(
+        [s1, s2, s3]
+      )
+      expect(ResultsPaginator.new(Submission.all, page: 0, per_page: 1).results_page).to eq(
+        [s1]
+      )
+      expect(ResultsPaginator.new(Submission.all, page: 1, per_page: 1).results_page).to eq(
+        [s2]
+      )
+      expect(ResultsPaginator.new(Submission.all, page: 2, per_page: 1).results_page).to eq(
+        [s3]
+      )
+    end
+  end
+
+  describe "#max_page" do
+    it "is a function of the result count and `per_page`" do
+      create_list(:submission, 3)
+
+      results = ResultsPaginator.new(Submission.all, page: 0, per_page: 1)
+
+      # three pages, started from 0
+      expect(results.max_page).to be(2)
+    end
+  end
+
+  describe "#offset" do
+    context "when we're on the first page" do
+      it "is 0" do
+        results = ResultsPaginator.new(Submission.all, page: 0, per_page: 25)
+
+        expect(results.offset).to be(0)
+      end
+    end
+
+    context "when we're on literally any other page" do
+      it "is the page number multipled by `per_page`" do
+        results = ResultsPaginator.new(Submission.all, page: 2, per_page: 69)
+
+        expect(results.offset).to be(138)
+      end
+    end
+  end
+end

--- a/spec/search_objects/submission_search_spec.rb
+++ b/spec/search_objects/submission_search_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SubmissionSearch do
+  describe "#results_pagination" do
+    it "is a `ResultsPaginator`" do
+      search = SubmissionSearch.new({})
+
+      expect(search.results_paginator).to be_a(ResultsPaginator)
+    end
+  end
+end

--- a/spec/support/page_objects/shared_components/pagination_component.rb
+++ b/spec/support/page_objects/shared_components/pagination_component.rb
@@ -1,0 +1,25 @@
+module PaginationComponent
+  def has_next_page?
+    within(".pagination-controls") do
+      has_css?("span.pagination-forward")
+    end
+  end
+
+  def has_previous_page?
+    within(".pagination-controls") do
+      has_css?("span.pagination-back")
+    end
+  end
+
+  def next_page
+    within(".pagination-controls") do
+      click_link t("shared.pagination_controls.next_page")
+    end
+  end
+
+  def previous_page
+    within(".pagination-controls") do
+      click_link t("shared.pagination_controls.previous_page")
+    end
+  end
+end

--- a/spec/support/page_objects/submissions_index_page.rb
+++ b/spec/support/page_objects/submissions_index_page.rb
@@ -1,9 +1,30 @@
 require "support/page_objects/page_base"
+require "support/page_objects/shared_components/pagination_component"
 
 class SubmissionsIndexPage < PageBase
+  include PaginationComponent
+
   def visit(as: nil)
     login_as(as) if as.present?
 
     super submissions_path
+  end
+
+  def has_submission_row_for?(submission)
+    has_css?("#submission_#{submission.id}") &&
+      has_correct_submission_info?(submission)
+  end
+
+  def has_correct_submission_info?(submission)
+    within find("#submission_#{submission.id}") do
+      has_proper_submission_link?(submission) &&
+        has_css?(".submission-user", text: submission.user.username)
+    end
+  end
+
+  def has_proper_submission_link?(submission)
+    url = submission.url.presence || submission_path(submission.id)
+
+    has_link?(submission.title, href: url)
   end
 end

--- a/spec/system/submissions_index_spec.rb
+++ b/spec/system/submissions_index_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe "submissions index" do
+  context "when a user visits the submission index" do
+    it "can view a list of submissions in descending order by default" do
+      submissions = create_pair(:submission)
+      page = SubmissionsIndexPage.new
+
+      page.visit
+
+      submissions.each do |s|
+        expect(page).to have_submission_row_for(s)
+      end
+
+      submission = submissions.last
+
+      expect(find(".submissions-list ol li", match: :first)).
+        to have_css(".submission-line1", text: submission.title)
+    end
+  end
+
+  context "when paginating results" do
+    context "when there are multiple pages" do
+      it "can page through them" do
+        # this is hacky as hell I know, but I don't want to
+        # create a ton of submissions as part of this setup
+        # to get it to page, so we'll do this for now.
+        # Open to better ways to do it.
+        stub_const("SubmissionSearch::DEFAULT_PER_PAGE", 2)
+        s1, s2, s3, s4, s5 = create_list(:submission, 5)
+        page = SubmissionsIndexPage.new
+
+        page.visit
+
+        expect(page).to have_next_page
+        expect(page).not_to have_previous_page
+
+        [s5, s4].each { |s| expect(page).to have_submission_row_for(s) }
+        [s1, s2, s3].each { |s| expect(page).not_to have_submission_row_for(s) }
+
+        # forward
+        page.next_page
+
+        expect(page).to have_next_page
+        expect(page).to have_previous_page
+
+        [s3, s2].each { |s| expect(page).to have_submission_row_for(s) }
+        [s1, s4, s5].each { |s| expect(page).not_to have_submission_row_for(s) }
+
+        page.next_page
+
+        expect(page).not_to have_next_page
+        expect(page).to have_previous_page
+
+        expect(page).to have_submission_row_for(s1)
+        [s2, s3, s4, s5].each { |s| expect(page).not_to have_submission_row_for(s) }
+
+        # and back
+        page.previous_page
+
+        expect(page).to have_next_page
+        expect(page).to have_previous_page
+
+        [s3, s2].each { |s| expect(page).to have_submission_row_for(s) }
+        [s1, s4, s5].each { |s| expect(page).not_to have_submission_row_for(s) }
+      end
+    end
+
+    context "when there is only one page" do
+      it "there are no paging controls" do
+        submission = create(:submission)
+        page = SubmissionsIndexPage.new
+
+        page.visit
+
+        expect(page).to have_submission_row_for(submission)
+        expect(page).not_to have_next_page
+        expect(page).not_to have_previous_page
+      end
+    end
+  end
+end


### PR DESCRIPTION
this commit adds most of what's needed for viewing
  submissions on the index.

I've added in skeletal
  links for things like saving / hiding submssions
  and viewing comments for now.

I've also added very basic pagination controls, which
  I think will be kept that way.