### PR TITLE
adds dotenv and configures translation exceptions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# raise exceptions when I18n translations are missing; useful for development + testing
+RAISE_ON_MISSING_TRANSLATIONS=TRUE

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+# raise exceptions when I18n translations are missing; useful for development + testing
+RAISE_ON_MISSING_TRANSLATIONS=TRUE

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "simple_form"
 
 group :development, :test do
   gem "bundler-audit"
+  gem "dotenv-rails"
   gem 'factory_bot_rails'
   gem 'haml_lint', require: false
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
     devise-i18n (1.9.1)
       devise (>= 4.7.1)
     diff-lcs (1.3)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     erubis (2.7.0)
     factory_bot (5.2.0)
@@ -310,6 +314,7 @@ DEPENDENCIES
   capybara
   devise
   devise-i18n
+  dotenv-rails
   factory_bot_rails
   formulaic
   haml-rails (~> 2.0)

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,6 @@
+if ENV['RAISE_ON_MISSING_TRANSLATIONS'] == 'TRUE'
+  I18n.exception_handler = lambda do |_exception, _locale, key, options|
+    full_key = [options[:scope], key].compact.join('.')
+    raise "Missing translation: #{full_key}"
+  end
+end


### PR DESCRIPTION
we add dotenv for managing environment variabels in dev/
  test. We also configure I18n to raise exceptions for missing
  translations in dev / test (on top of areas outside of views).