### PR TITLE
adds URL Parser

### DIFF
--- a/app/util/url_parser.rb
+++ b/app/util/url_parser.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class UrlParser
+  def self.parse(url)
+    new(url).parse if url.present?
+  end
+
+  def initialize(raw_url)
+    @raw_url = raw_url
+  end
+
+  attr_reader :raw_url
+
+  def parse
+    # we're only allowing HTTP. If they try to give us something
+    # else, or an otherwise invalid URI, we'll return `nil`.
+    uri = URI.parse(raw_url)
+    case uri
+    when URI::HTTP, URI::HTTPS
+      extract_data(uri)
+    else
+      { status: :error, error: I18n.t("url.error.scheme", scheme: uri.scheme) }
+    end
+  end
+
+  private
+
+  def extract_data(uri)
+    initialize_parsed_attributes(uri).then do |attrs|
+      # they need to at least give us a scheme and host
+      if attrs[:scheme].present? && attrs[:host].present?
+        build_result(attrs)
+      else
+        { status: :error, error: I18n.t("url.error.invalid", url: raw_url) }
+      end
+    end
+  end
+
+  def build_result(attrs)
+    [
+      "#{attrs[:scheme]}://",
+      ("#{attrs[:userinfo]}@" if attrs[:userinfo].present?),
+      (attrs[:host]).to_s,
+      (":#{attrs[:port]}" if attrs[:port].present?),
+      (attrs[:path]).to_s,
+      ("?#{attrs[:query]}" if attrs[:query].present?),
+      ("##{attrs[:fragment]}" if attrs[:fragment].present?)
+    ].join.then { |url| attrs.merge(url: url, status: :ok) }
+  end
+
+  def initialize_parsed_attributes(uri)
+    {
+      scheme: uri.scheme,
+      userinfo: uri.userinfo,
+      host: clean_host(uri.host),
+      port: maybe_port(uri.scheme, uri.port),
+      path: uri.path,
+      query: clean_query(uri.query),
+      fragment: uri.fragment
+    }
+  end
+
+  def clean_host(host)
+    # removes `www\d?.` prefixes so that we don't treat the same page
+    # different because one URL might have `www.` and the other
+    # might not
+    host.sub(/www\d?\./, "") if host.present?
+  end
+
+  def maybe_port(scheme, port)
+    # remove common http / https ports from URL so that if we see the
+    # URL without the port we don't consider it the same.
+    unless scheme == "http" && port == 80 || scheme == "https" && port == 443
+      port
+    end
+  end
+
+  def clean_query(query)
+    # remove creepy trackers
+    # todo: expand on this
+    if query.present?
+      query.split("&").
+        reject { |param| param.match(/^utm_(source|medium|campaign|term|content)=|^sk=|^fbclid=/) }.
+        join("&")
+    end
+  end
+end

--- a/config/locales/url.en.yml
+++ b/config/locales/url.en.yml
@@ -1,0 +1,5 @@
+en:
+  url:
+    error:
+      scheme: "unaccepted URL scheme: %{scheme}"
+      invalid: "invalid URL: %{url}"

--- a/spec/util/url_parser_spec.rb
+++ b/spec/util/url_parser_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe UrlParser do
+  describe ".parse" do
+    it "parses the URL and returns a result hash containing a cleaned URL and other info" do
+      url = "https://www.foo.com/path/to/article?utm_medium=1&foo=bar#bop"
+
+      expect(UrlParser.parse(url)).to eq(
+        {
+          scheme: "https",
+          userinfo: nil,
+          host: "foo.com",
+          port: nil,
+          path: "/path/to/article",
+          query: "foo=bar",
+          fragment: "bop",
+          url: "https://foo.com/path/to/article?foo=bar#bop",
+          status: :ok
+        }
+      )
+    end
+
+    context "when it's a wwwx prepended url" do
+      it "parses the URL without error" do
+        expect(UrlParser.parse("https://www.foo.com")).to include(url: "https://foo.com")
+        expect(UrlParser.parse("https://www2.foo.com")).to include(url: "https://foo.com")
+        expect(UrlParser.parse("https://www3.foo.com")).to include(url: "https://foo.com")
+      end
+    end
+
+    context "when there is userinfo in the url" do
+      it "keeps it in the result" do
+        expect(UrlParser.parse("https://bar@www.foo.com")).to include(url: "https://bar@foo.com")
+      end
+    end
+
+    context "when there is a port present" do
+      context "when the scheme is http and the port is 80" do
+        it "removes the port from the result" do
+          expect(UrlParser.parse("http://www.foo.com:80")).to include(url: "http://foo.com")
+        end
+      end
+
+      context "when the scheme is https and the port is 443" do
+        it "removes the port from the result" do
+          expect(UrlParser.parse("https://www.foo.com:443")).to include(url: "https://foo.com")
+        end
+      end
+
+      context "when the port is neither 80 nor 443" do
+        it "appends the port to the result" do
+          expect(UrlParser.parse("http://www.foo.com:666")).to include(url: "http://foo.com:666")
+          expect(UrlParser.parse("https://www.foo.com:666")).to include(url: "https://foo.com:666")
+        end
+      end
+    end
+
+    context "when there are query parameters" do
+      context "when there are tracker query parameters" do
+        it "removes the trackers from the result and leaves the rest" do
+          expect(UrlParser.parse("https://www.foo.com?utm_source=1&foo=bar")).
+            to include(url: "https://foo.com?foo=bar")
+        end
+      end
+    end
+
+    context "when there is a fragment" do
+      it "includes it in the result" do
+        expect(UrlParser.parse("https://www.foo.com#bar")).to include(url: "https://foo.com#bar")
+      end
+    end
+
+    context "when the URL has an unaccepted scheme or scheme is missing" do
+      it "returns a hash with an error message" do
+        expect(UrlParser.parse("ftp://user@host/foo")).to eq({
+          status: :error,
+          error: I18n.t("url.error.scheme", scheme: "ftp")
+        })
+
+        expect(UrlParser.parse("foo.com")).to eq({
+          status: :error,
+          error: I18n.t("url.error.scheme", scheme: nil)
+        })
+      end
+    end
+
+    context "when the URL has nothing but a scheme (first of all, wtf)" do
+      it "returns a hash with an error message" do
+        expect(UrlParser.parse("http://")).to eq({
+          status: :error,
+          error: I18n.t("url.error.invalid", url: "http://")
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
this commit adds a URL parser which is to be used as
  part of the submission creation process.

essentially it's a wrapper around `URI.parse`, with some
  additional functionality.

It:

- enforces the validity of domains (scheme must be present and
  either http or https)

- removes `www\d*` prefixes from domains to prevent multiple entries
  for what amounts to the same domain (from a practical perspective)

- removes common ports for http / https in order to prevent multiple
  entries for the same domain, but with a port included that does not
  make a meaningful distinction (i.e. http + port 80)

- removes (some) known tracking query parameters. We'll obviously need
  to iterate on this