### PR TITLE
adds Domain model

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Domain < ApplicationRecord
+  belongs_to :banned_by, class_name: "User", optional: true
+  has_many :submissions
+
+  def banned?
+    banned_at.present?
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,3 +1,4 @@
 class Submission < ApplicationRecord
   belongs_to :user
+  belongs_to :domain, optional: true
 end

--- a/db/migrate/20200511231149_create_domains.rb
+++ b/db/migrate/20200511231149_create_domains.rb
@@ -1,0 +1,15 @@
+class CreateDomains < ActiveRecord::Migration[6.0]
+  def change
+    create_table :domains do |t|
+      t.string :name, null: false
+      t.boolean :tracker, null: false, default: false
+      t.datetime :banned_at
+      t.belongs_to :banned_by, null: true, index: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :domains, :name, unique: true
+    add_index :domains, :banned_by_id, where: "banned_by_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20200512030843_add_domain_to_submissions.rb
+++ b/db/migrate/20200512030843_add_domain_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddDomainToSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :submissions, :domain, null: true, index: false, foreign_key: true
+    add_index :submissions, :domain_id, where: "domain_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_10_221526) do
+ActiveRecord::Schema.define(version: 2020_05_12_030843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "domains", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "tracker", default: false, null: false
+    t.datetime "banned_at"
+    t.bigint "banned_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["banned_by_id"], name: "index_domains_on_banned_by_id", where: "(banned_by_id IS NOT NULL)"
+    t.index ["name"], name: "index_domains_on_name", unique: true
+  end
 
   create_table "submissions", force: :cascade do |t|
     t.string "title", limit: 175, null: false
@@ -23,6 +34,8 @@ ActiveRecord::Schema.define(version: 2020_05_10_221526) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "original_author", default: false, null: false
+    t.bigint "domain_id"
+    t.index ["domain_id"], name: "index_submissions_on_domain_id", where: "(domain_id IS NOT NULL)"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
@@ -51,5 +64,7 @@ ActiveRecord::Schema.define(version: 2020_05_10_221526) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "domains", "users", column: "banned_by_id"
+  add_foreign_key "submissions", "domains"
   add_foreign_key "submissions", "users"
 end

--- a/spec/factories/domains.rb
+++ b/spec/factories/domains.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :domain do
+    sequence(:name) { |n| "domain#{n}.com" }
+    tracker { false }
+    banned_at { nil }
+    banned_by { nil }
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     body { nil }
     user
     original_author { false }
+    domain
   end
 end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Domain, type: :model do
+  it { should belong_to(:banned_by).class_name("User").optional }
+  it { should have_many(:submissions) }
+
+  describe "#banned?" do
+    it "is true when `banned_at` is present" do
+      expect(build(:domain, banned_at: Time.zone.now).banned?).to eq(true)
+    end
+
+    it "is false when `banned_at` is not present" do
+      expect(build(:domain, banned_at: nil).banned?).to eq(false)
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,3 +1,4 @@
 RSpec.describe Submission, type: :model do
   it { should belong_to(:user) }
+  it { should belong_to(:domain).optional }
 end


### PR DESCRIPTION
This commit adds a model to represent the underlying
  `domain` that a submission comes from.

This is useful for being able to do things like ban URLs
  from a given domain (if it's found to have malware, creepier
  than usual tracking, bad informatin, etc.).

It also adds a foreign key reference to the submissions table.

Submissions may or may not have a domain, depending on whether or
  not it is a URL or text submission.