### PR TITLE
adds URL Health Check Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.1'
 
+# http
+gem "faraday"
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3'
 # Use postgresql as the database for Active Record
@@ -65,6 +68,7 @@ group :test do
   gem "formulaic"
   gem "rspec_junit_formatter"
   gem "selenium-webdriver"
+  gem "webmock"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -103,6 +105,8 @@ GEM
     factory_bot_rails (5.2.0)
       factory_bot (~> 5.2.0)
       railties (>= 4.2.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     formulaic (0.4.1)
       activesupport
@@ -124,6 +128,7 @@ GEM
       rainbow
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
+    hashdiff (1.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -150,6 +155,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -244,6 +250,7 @@ GEM
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
     rubyzip (2.3.0)
+    safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.3.0)
@@ -292,6 +299,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -316,6 +327,7 @@ DEPENDENCIES
   devise-i18n
   dotenv-rails
   factory_bot_rails
+  faraday
   formulaic
   haml-rails (~> 2.0)
   haml_lint
@@ -339,6 +351,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  webmock
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/services/url_health_check_service.rb
+++ b/app/services/url_health_check_service.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "resolv"
+
+# this is definitely not as robust as it can, and maybe should be
+# I welcome anyone to expand on it or re-approach it entirely.
+class UrlHealthCheckService
+  def initialize(base_uri)
+    @base_uri = base_uri
+    @ending_uri = base_uri
+  end
+
+  def healthy?
+    # I find it odd that anyone would submit a literal IP.
+    # Given that the underlying IPs can change while the
+    # URL may stay the same, I'm opting to reject IPs
+    # entirely.
+    not_an_ip? && healthy_response_or_redirect?
+  end
+
+  attr_reader :base_uri, :ending_uri
+
+  private
+
+  def not_an_ip?
+    (Resolv::IPv4::Regex =~ base_uri.host).nil? &&
+      (Resolv::IPv6::Regex =~ base_uri.host).nil?
+  end
+
+  def healthy_response_or_redirect?
+    case base_uri.scheme
+    when "https"
+      healthy_over_ssl?(base_uri)
+    when "http"
+      # try with SSL just in case the user forgot to specifiy
+      https_uri = base_uri.dup.tap { |uri| uri.scheme = "https" }.then { |uri| URI.parse(uri.to_s) }
+      healthy_over_ssl?(https_uri) || healthy_response?(base_uri)
+    else
+      raise "unsupported URI scheme"
+    end
+  end
+
+  def healthy_over_ssl?(uri)
+    # this is an incredibly naive check. basically, if there is something
+    # insanely wrong, we'll encounter a Faraday SSL error
+    uri.scheme == "https" && healthy_response?(uri)
+  end
+
+  def healthy_response?(uri)
+    response = Faraday.get(uri)
+    if response.success?
+      @ending_uri = uri
+      true
+    else
+      healthy_redirect?(response)
+    end
+  rescue Faraday::ConnectionFailed, Faraday::SSLError, Faraday::TimeoutError, OpenSSL::SSL::SSLError
+    # if any of the above happen then the URL is considered unhealthy. We don't
+    # care why. At this point the user should verify it's formatted correctly
+    # and that the file exists at the location
+    false
+  end
+
+  def healthy_redirect?(response, limit = 10)
+    if limit.zero?
+      false
+    else
+      is_redirect?(response) && succeeds_in_redirection?(response, limit)
+    end
+  end
+
+  def succeeds_in_redirection?(response, limit)
+    location = response.headers["location"]
+    redirect_response = Faraday.get(URI.parse(location)) if location.present?
+    if redirect_response.present? && redirect_response.success?
+      # save the redirect uri so we / the client can just go straight to the
+      # resource in the future
+      @ending_uri = URI.parse(location)
+      true
+    else
+      healthy_redirect?(redirect_response, limit - 1)
+    end
+  end
+
+  def is_redirect?(response)
+    # I realize that some of these redirect codes we don't care about in practice
+    # but this is a lot neater than enumerating them all
+    (300..308).include?(response.status)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,14 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+# This file is copied to spec/ when you run "rails generate rspec:install"
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
-require 'capybara/rails'
-require 'capybara/rspec'
-require 'selenium/webdriver'
+require "rspec/rails"
+require "capybara/rails"
+require "capybara/rspec"
+require "selenium/webdriver"
+require "webmock/rspec"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,7 +24,7 @@ require 'selenium/webdriver'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -58,3 +59,5 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/services/url_health_check_service_spec.rb
+++ b/spec/services/url_health_check_service_spec.rb
@@ -1,0 +1,137 @@
+RSpec.describe UrlHealthCheckService do
+  describe "#healthy?" do
+    context "when the given URI's scheme is https" do
+      context "when the request is valid over https" do
+        it "returns true" do
+          url = "https://example.com"
+          stub_check_response(url)
+          uri = URI.parse(url)
+
+          service = UrlHealthCheckService.new(uri)
+
+          expect(service).to be_healthy
+          expect(service.ending_uri).to eq(uri)
+        end
+      end
+
+      context "when the request is not valid over https" do
+        it "returns false" do
+          url = "https://example.com"
+          stub_check_response(url, status: 500)
+          uri = URI.parse(url)
+
+          service = UrlHealthCheckService.new(uri)
+
+          expect(service).not_to be_healthy
+        end
+      end
+    end
+
+    context "when the given URI's scheme is http" do
+      it "checks to see if the request would be valid over https and returns true if valid" do
+        url = "http://example.com"
+        https_url = "https://example.com"
+        stub_check_response(https_url)
+        uri = URI.parse(url)
+
+        service = UrlHealthCheckService.new(uri)
+
+        expect(service).to be_healthy
+        expect(service.ending_uri).to eq(URI.parse(https_url))
+      end
+
+      it "returns true if the request is not valid over https but valid over http" do
+        url = "http://example.com"
+        https_url = "https://example.com"
+        stub_check_response(url)
+        stub_check_response(https_url, status: 500)
+        uri = URI.parse(url)
+
+        service = UrlHealthCheckService.new(uri)
+
+        expect(service).to be_healthy
+        expect(service.ending_uri).to eq(uri)
+      end
+
+      it "returns false when the request is valid over neither http nor https" do
+        url = "http://example.com"
+        https_url = "https://example.com"
+        stub_check_response(url, status: 500)
+        stub_check_response(https_url, status: 500)
+        uri = URI.parse(url)
+
+        service = UrlHealthCheckService.new(uri)
+
+        expect(service).not_to be_healthy
+      end
+    end
+
+    context "when there are redirects" do
+      context "when there are 10 or less redirects" do
+        it "returns true if the final response is valid and updates the `ending_uri` to its URI" do
+          # this is something you'll see often
+          url = "https://example.com"
+          www_url = "https://www.example.com"
+          stub_check_response(url, status: 302, headers: { "location" => www_url })
+          stub_check_response(www_url, status: 200)
+
+          uri = URI.parse(url)
+
+          service = UrlHealthCheckService.new(uri)
+
+          expect(service).to be_healthy
+          expect(service.ending_uri).to eq(URI.parse(www_url))
+        end
+
+        it "returns false if the final response is invalid" do
+          url = "https://example.com"
+          www_url = "https://www.example.com"
+          stub_check_response(url, status: 302, headers: { "location" => www_url })
+          stub_check_response(www_url, status: 500)
+
+          uri = URI.parse(url)
+
+          service = UrlHealthCheckService.new(uri)
+
+          expect(service).not_to be_healthy
+        end
+      end
+
+      context "when there are more than 10 redirects" do
+        it "returns false" do
+          url = "https://example.com"
+          www_url = "https://www.example.com"
+          # I'm being a troll and causing an infinite redirect
+          stub_check_response(url, status: 302, headers: { "location" => www_url })
+          stub_check_response(www_url, status: 302, headers: { "location" => url })
+
+          uri = URI.parse(url)
+
+          service = UrlHealthCheckService.new(uri)
+
+          expect(service).not_to be_healthy
+        end
+      end
+    end
+
+    context "when the given URI's scheme is neither https nor http" do
+      it "returns false" do
+        uri = URI.parse("ftp://ftp.foo.com")
+
+        expect { UrlHealthCheckService.new(uri).healthy? }.to raise_error("unsupported URI scheme")
+      end
+    end
+
+    context "when the URI involves an IP address" do
+      it "returns false" do
+        uri = URI.parse("http://192.168.1.1")
+
+        expect(UrlHealthCheckService.new(uri)).not_to be_healthy
+      end
+    end
+  end
+end
+
+def stub_check_response(url, status: 200, headers: {}, body: "")
+  stub_request(:get, url).to_return(body: body, headers: headers, status: status)
+end


### PR DESCRIPTION
This commits adds in a (naive) URL health check service.

Basically, when the user submits a URL, we want to make sure that
  it's valid / the destination exists, so we try to make a request.

In the case of redirects, the service also keeps track of the final
  destination so that we can store it directly instead of forcing
  users to follow all the redirects.

We also disallow the use of IPs, because IPs are not necessarily
  long lived like URLs (someone can move their application to another
  server and keep the same domain, the same isn't true for an IP).