### PR TITLE
Adds the ability to submit and view submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'puma', '~> 4.1'
 gem 'sass-rails', '>= 6'
 gem 'bourbon'
 gem 'bitters'
+# commonmarker for markdown support
+gem "commonmarker"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.2)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -246,6 +248,8 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
+    ruby-enum (0.8.0)
+      i18n
     ruby-progressbar (1.10.1)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -323,6 +327,7 @@ DEPENDENCIES
   bourbon
   bundler-audit
   capybara
+  commonmarker
   devise
   devise-i18n
   dotenv-rails

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -104,3 +104,12 @@ select {
     outline: none;
   }
 }
+
+.errors {
+  list-style-type: circle;
+  margin-left: $spacing;
+  margin-bottom: $spacing-smaller;
+  .error {
+    color: $red;
+  }
+}

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -1,19 +1,22 @@
 // Colors
+$alto: #cecece;
 $blue: #1565c0;
 $blue-light: #3b83d5;
 $blue-light-very: #f4fbff;
 $congress-blue: #004e98;
+$gallery: #ebebeb;
 $gray: #333;
 $off-indigo: #4f86c6;
+$red: #ff0000;
 $scorpion: #606060;
 $white: #fff;
 $white-gray: #fafafa;
 
 // Font Colors
 $font-color--base: $gray;
-$action-color: $blue;
+$action-color: $congress-blue;
 $action-color--alt: $blue-light;
-$action-color--contrast: $white;
+$action-color--contrast: $gallery;
 
 // Background Colors
 $base-background-color: $white;
@@ -68,11 +71,13 @@ $line-height-heading: 1.2;
 // Borders
 $border-radius: 0.1875rem;
 $border: 0.0625rem solid $gray;
+$light-border: 1px solid $alto;
 
 // Spacing
 $spacing: 1.5rem;
 $spacing-small: 0.75rem;
 $spacing-smaller: 0.5rem;
+$spacing-xs: 0.25rem;
 
 // Focus
 $focus-outline: 0.1875rem solid #{$action-color};

--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -1,40 +1,60 @@
 .submissions-list {
   @include padding($spacing-smaller null null null);
+}
 
-  ol {
-    li {
-      @include padding(null null $spacing-small null);
-      .submission-line1 {
-        .submission-link a {
-          text-decoration: none;
-          font-size: 1.2rem;
-          font-weight: $font-weight-bold;
-        }
-      }
-      .submission-line2 {
-        .submission-info, .submission-comments {
-          color: $scorpion;
-          a {
-            text-decoration: none;
-            color: $scorpion;
-          }
-        }
+.submission {
+  @include padding(null null $spacing-small null);
+  .submission-info, .submission-comments {
+    color: $scorpion;
+    a {
+      text-decoration: none;
+      color: $scorpion;
+    }
+  }
+  .submission-line1 {
+    .submission-link a {
+      text-decoration: none;
+      font-size: 1.2rem;
+      font-weight: $font-weight-bold;
+      margin-right: $spacing-xs;
+    }
+  }
+  .submission-line2 {
+    .submission-time::after {
+      content: "|";
+    }
 
-        .submission-time::after {
-          content: "|";
-        }
+    .submission-info a::after {
+      @include margin(null 1px null null);
+      @include padding(null null null 4px);
+      content: "|";
+      font-size: 1rem;
+    }
+    .submission-user {
+      color: $off-indigo;
+      a { text-decoration: none; }
+    }
+  }
+}
 
-        .submission-info a::after {
-          @include margin(null 1px null null);
-          @include padding(null null null 4px);
-          content: "|";
-          font-size: 1rem;
-        }
-        .submission-user {
-          color: $off-indigo;
-          a { text-decoration: none; }
-        }
-      }
+.submission-body {
+  border-top: $light-border;
+  padding-top: $spacing-smaller
+}
+
+.original-author-statement {
+  padding-top: $spacing-smaller;
+  margin-bottom: $spacing-smaller;
+  .left-hand-label {
+    display: inline-block;
+  }
+}
+
+@media only screen and (max-width: 1155px) {
+  .submissions-list {
+    .submission {
+      border-bottom: $light-border;
+      margin-bottom: $spacing-smaller;
     }
   }
 }

--- a/app/assets/stylesheets/shared/_simple_form.scss
+++ b/app/assets/stylesheets/shared/_simple_form.scss
@@ -5,3 +5,12 @@ form {
     display: block;
   }
 }
+
+.left-hand-label {
+  * {
+    display: inline-block;
+  }
+  label:first-child {
+    margin-right: $spacing-smaller;
+  }
+}

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,9 +1,32 @@
 class SubmissionsController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create]
+
   def index
     @paginator = SubmissionSearch.new(submission_search_params).results_paginator
   end
 
+  def show
+    @submission = Submission.preload(:user, :domain).find(params[:id])
+  end
+
+  def new
+    @form = CreateSubmissionForm.new({}, current_user)
+  end
+
+  def create
+    @form = CreateSubmissionForm.new(create_submission_params, current_user)
+    if @form.save
+      redirect_to submission_path(@form.submission.id)
+    else
+      render :new
+    end
+  end
+
   private
+
+  def create_submission_params
+    params.require(:create_submission_form).permit(:url, :title, :body, :original_author)
+  end
 
   def submission_search_params
     params.permit(:page, :per_page)

--- a/app/form_objects/create_submission_form.rb
+++ b/app/form_objects/create_submission_form.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# this should probably be revisted sometime in the
+# near future
+class CreateSubmissionForm
+  include ActiveModel::Model
+
+  MODEL_NAME = "CreateSubmissionForm"
+  I18N_PREFIX = "submissions.new.error"
+
+  validates :title, presence: { message: I18n.t("#{I18N_PREFIX}.title_missing") },
+    length: { in: (10..175), message: I18n.t("#{I18N_PREFIX}.title_length") }
+  validate :url_xor_body
+  validate :domain_and_url_valid, if: ->(f) { f.url.present? && f.body.blank? }
+
+  def initialize(params, user)
+    stripped_params = params.each_value(&:strip!).select { |_, v| v.present? }
+    @user = user
+    super(stripped_params)
+  end
+
+  def save
+    @submission = initialize_submission
+    if valid?
+      @submission.url = url if url.present?
+      @submission.domain = domain if domain.present?
+      @submission.save
+    end
+  end
+
+  attr_accessor :title, :url, :domain, :body, :original_author, :user, :submission
+
+  private
+
+  def initialize_submission
+    Submission.new(
+      title: title,
+      body: body,
+      original_author: original_author.to_i.eql?(1),
+      user: user
+    )
+  end
+
+  def url_xor_body
+    unless url.present? ^ body.present?
+      errors.add(:base, I18n.t("#{I18N_PREFIX}.url_or_body"))
+    end
+  end
+
+  def domain_and_url_valid
+    cleaned_url_result = UrlParser.parse(url)
+    if cleaned_url_result[:status] == :ok
+      validate_and_assign_domain(cleaned_url_result[:host])
+      validate_and_set_url(cleaned_url_result[:url]) unless domain.banned?
+    else
+      errors.add(:url, cleaned_url_result[:error])
+    end
+  end
+
+  def validate_and_assign_domain(domain_name)
+    @domain = Domain.find_or_initialize_by(name: domain_name)
+    if domain.banned?
+      errors.add(:domain, I18n.t("#{I18N_PREFIX}.banned_domain", domain: domain.name))
+    end
+  end
+
+  def validate_and_set_url(cleaned_url)
+    uri = URI.parse(cleaned_url)
+    health_checker = UrlHealthCheckService.new(uri)
+    if health_checker.healthy?
+      ending_uri = health_checker.ending_uri
+      if uri != ending_uri
+        assign_domain_and_url_from_healthcheck_ending_uri(ending_uri)
+      else
+        @url = cleaned_url
+      end
+      check_for_existing_submission
+    else
+      errors.add(:url, I18n.t("#{I18N_PREFIX}.url_health"))
+    end
+  end
+
+  def assign_domain_and_url_from_healthcheck_ending_uri(ending_uri)
+    # we were redirected to a different URL so we need to re-validate
+    # that everything is allowed / cleaned up.
+    cleaned_url_result = UrlParser.parse(ending_uri.to_s)
+    if cleaned_url_result[:status] == :ok
+      validate_and_assign_domain(cleaned_url_result[:host])
+      @url = cleaned_url_result[:url]
+    else
+      errors.add(:url, cleaned_url_result[:error])
+    end
+  end
+
+  def check_for_existing_submission
+    errors.add(:url, I18n.t("#{I18N_PREFIX}.url_exists")) if Submission.where(url: url).exists?
+  end
+end

--- a/app/javascript/latex_styles.sass
+++ b/app/javascript/latex_styles.sass
@@ -1,0 +1,1 @@
+@import '~katex/dist/katex.min'

--- a/app/javascript/packs/latex.js
+++ b/app/javascript/packs/latex.js
@@ -1,0 +1,244 @@
+import '../latex_styles';
+
+const katex = require('katex');
+
+const findEndOfMath = function(delimiter, text, startIndex) {
+    // Adapted from
+    // https://github.com/Khan/perseus/blob/master/src/perseus-markdown.jsx
+    let index = startIndex;
+    let braceLevel = 0;
+
+    const delimLength = delimiter.length;
+
+    while (index < text.length) {
+        const character = text[index];
+
+        if (braceLevel <= 0 &&
+            text.slice(index, index + delimLength) === delimiter) {
+            return index;
+        } else if (character === "\\") {
+            index++;
+        } else if (character === "{") {
+            braceLevel++;
+        } else if (character === "}") {
+            braceLevel--;
+        }
+
+        index++;
+    }
+
+    return -1;
+};
+
+const splitAtDelimiters = function(startData, leftDelim, rightDelim, display) {
+    const finalData = [];
+
+    for (let i = 0; i < startData.length; i++) {
+        if (startData[i].type === "text") {
+            const text = startData[i].data;
+
+            let lookingForLeft = true;
+            let currIndex = 0;
+            let nextIndex;
+
+            nextIndex = text.indexOf(leftDelim);
+            if (nextIndex !== -1) {
+                currIndex = nextIndex;
+                finalData.push({
+                    type: "text",
+                    data: text.slice(0, currIndex),
+                });
+                lookingForLeft = false;
+            }
+
+            while (true) {
+                if (lookingForLeft) {
+                    nextIndex = text.indexOf(leftDelim, currIndex);
+                    if (nextIndex === -1) {
+                        break;
+                    }
+
+                    finalData.push({
+                        type: "text",
+                        data: text.slice(currIndex, nextIndex),
+                    });
+
+                    currIndex = nextIndex;
+                } else {
+                    nextIndex = findEndOfMath(
+                        rightDelim,
+                        text,
+                        currIndex + leftDelim.length);
+                    if (nextIndex === -1) {
+                        break;
+                    }
+
+                    finalData.push({
+                        type: "math",
+                        data: text.slice(
+                            currIndex + leftDelim.length,
+                            nextIndex),
+                        rawData: text.slice(
+                            currIndex,
+                            nextIndex + rightDelim.length),
+                        display: display,
+                    });
+
+                    currIndex = nextIndex + rightDelim.length;
+                }
+
+                lookingForLeft = !lookingForLeft;
+            }
+
+            finalData.push({
+                type: "text",
+                data: text.slice(currIndex),
+            });
+        } else {
+            finalData.push(startData[i]);
+        }
+    }
+
+    return finalData;
+};
+
+const splitWithDelimiters = function(text, delimiters) {
+    let data = [{type: "text", data: text}];
+    for (let i = 0; i < delimiters.length; i++) {
+        const delimiter = delimiters[i];
+        data = splitAtDelimiters(
+            data, delimiter.left, delimiter.right,
+            delimiter.display || false);
+    }
+    return data;
+};
+
+/* Note: optionsCopy is mutated by this method. If it is ever exposed in the
+ * API, we should copy it before mutating.
+ */
+const renderMathInText = function(text, optionsCopy) {
+    const data = splitWithDelimiters(text, optionsCopy.delimiters);
+    if (data.length === 1 && data[0].type === 'text') {
+        // There is no formula in the text.
+        // Let's return null which means there is no need to replace
+        // the current text node with a new one.
+        return null;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    for (let i = 0; i < data.length; i++) {
+        if (data[i].type === "text") {
+            fragment.appendChild(document.createTextNode(data[i].data));
+        } else {
+            const span = document.createElement("span");
+            let math = data[i].data;
+            // Override any display mode defined in the settings with that
+            // defined by the text itself
+            optionsCopy.displayMode = data[i].display;
+            try {
+                if (optionsCopy.preProcess) {
+                    math = optionsCopy.preProcess(math);
+                }
+                katex.render(math, span, optionsCopy);
+            } catch (e) {
+                if (!(e instanceof katex.ParseError)) {
+                    throw e;
+                }
+                optionsCopy.errorCallback(
+                    "KaTeX auto-render: Failed to parse `" + data[i].data +
+                    "` with ",
+                    e
+                );
+                fragment.appendChild(document.createTextNode(data[i].rawData));
+                continue;
+            }
+            fragment.appendChild(span);
+        }
+    }
+
+    return fragment;
+};
+
+const renderElem = function(elem, optionsCopy) {
+    for (let i = 0; i < elem.childNodes.length; i++) {
+        const childNode = elem.childNodes[i];
+        if (childNode.nodeType === 3) {
+            // Text node
+            const frag = renderMathInText(childNode.textContent, optionsCopy);
+            if (frag) {
+                i += frag.childNodes.length - 1;
+                elem.replaceChild(frag, childNode);
+            }
+        } else if (childNode.nodeType === 1) {
+            // Element node
+            const className = ' ' + childNode.className + ' ';
+            const shouldRender = optionsCopy.ignoredTags.indexOf(
+                childNode.nodeName.toLowerCase()) === -1 &&
+                    optionsCopy.ignoredClasses.every(
+                        x => className.indexOf(' ' + x + ' ') === -1);
+
+            if (shouldRender) {
+                renderElem(childNode, optionsCopy);
+            }
+        }
+        // Otherwise, it's something else, and ignore it.
+    }
+};
+
+const renderMathInElement = function(elem, options) {
+    if (!elem) {
+        throw new Error("No element provided to render");
+    }
+
+    const optionsCopy = {};
+
+    // Object.assign(optionsCopy, option)
+    for (const option in options) {
+        if (options.hasOwnProperty(option)) {
+            optionsCopy[option] = options[option];
+        }
+    }
+
+    // default options
+    optionsCopy.delimiters = optionsCopy.delimiters || [
+        {left: "$$", right: "$$", display: true},
+        {left: "\\(", right: "\\)", display: false},
+        // LaTeX uses $…$, but it ruins the display of normal `$` in text:
+        // {left: "$", right: "$", display: false},
+
+        //  \[…\] must come last in this array. Otherwise, renderMathInElement
+        //  will search for \[ before it searches for $$ or  \(
+        // That makes it susceptible to finding a \\[0.3em] row delimiter and
+        // treating it as if it were the start of a KaTeX math zone.
+        {left: "\\[", right: "\\]", display: true},
+    ];
+    optionsCopy.ignoredTags = optionsCopy.ignoredTags || [
+        "script", "noscript", "style", "textarea", "pre", "code", "option",
+    ];
+    optionsCopy.ignoredClasses = optionsCopy.ignoredClasses || [];
+    optionsCopy.errorCallback = optionsCopy.errorCallback || console.error;
+
+    // Enable sharing of global macros defined via `\gdef` between different
+    // math elements within a single call to `renderMathInElement`.
+    optionsCopy.macros = optionsCopy.macros || {};
+
+    renderElem(elem, optionsCopy);
+};
+
+const callback = function() {
+  const elements = document.getElementsByClassName("latex-container");
+
+  for (let i = 0; i < elements.length; i++) {
+    renderMathInElement(elements[i]);
+  }
+};
+
+if (
+    document.readyState === "complete" ||
+    (document.readyState !== "loading" && !document.documentElement.doScroll)
+) {
+  callback();
+} else {
+  document.addEventListener("DOMContentLoaded", callback);
+}

--- a/app/search_objects/submission_search.rb
+++ b/app/search_objects/submission_search.rb
@@ -15,7 +15,7 @@ class SubmissionSearch
   attr_reader :params
 
   def scope
-    Submission.preload(:user).all
+    Submission.preload(:user, :domain)
   end
 
   def pagination_params

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -12,7 +12,7 @@
         %li
           %span= link_to t("navigation.links.recent"), "#"
         %li
-          %span= link_to t("navigation.links.submit"), "#"
+          %span= link_to t("navigation.links.submit"), new_submission_path
         %li
           %span= link_to t("navigation.links.your_submissions"), "#"
         %li

--- a/app/views/submissions/_submission_list.html.haml
+++ b/app/views/submissions/_submission_list.html.haml
@@ -1,5 +1,6 @@
 .submissions-list
   %ol
     - submissions.each do |s|
-      = render "submission_list_item", submission: s
+      %li
+        = render "submission_list_item", submission: s
 

--- a/app/views/submissions/_submission_list_item.html.haml
+++ b/app/views/submissions/_submission_list_item.html.haml
@@ -1,6 +1,8 @@
-%li{ id: "submission_#{submission.id}" }
+.submission{ id: "submission_#{submission.id}" }
   .submission-line1
     %span.submission-link= link_to(submission.title, submission_href_for(submission))
+    %span.submission-info
+      %i= submission.domain.name if submission.domain.present?
   .submission-line2
     %span.submission-info
       = submitted_by_text(submission)

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,0 +1,12 @@
+%h2= t(".title")
+%ul.errors
+  - @form.errors.values.flatten.map do |e|
+    %li.error= e
+= simple_form_for @form, url: submissions_path do |f|
+  = f.input :url
+  = f.input :title
+  = f.input :body, as: :text, input_html: { rows: 15 }
+  .original-author-statement
+    = f.input :original_author, as: :boolean, wrapper: :left_hand_label
+    = t(".original_author")
+  = f.submit

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -1,0 +1,5 @@
+= render "submission_list_item", submission: @submission
+.submission-body.latex-container
+  = sanitize CommonMarker.render_html(@submission.body.gsub("\\", "\\\\\\")) if @submission.body.present?
+
+= javascript_pack_tag :latex

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -64,6 +64,11 @@ SimpleForm.setup do |config|
     # b.use :full_error, wrap_with: { tag: :span, class: :error }
   end
 
+  config.wrappers :left_hand_label, class: "left-hand-label" do |b|
+    b.use :label
+    b.use :input
+  end
+
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,8 @@
 
 en:
   hello: "Hello world"
+
+  helpers:
+    submit:
+      create_submission_form:
+        create: "Create Submission"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,8 @@
+en:
+  simple_form:
+    labels:
+      create_submission_form:
+        url: "URL:"
+        title: "Title:"
+        body: "Body:"
+        original_author: "Original author:"

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -7,3 +7,16 @@ en:
       hide: hide
       save: save
       comments: "%{count} comments"
+    new:
+      title: Make a new submission
+      original_author: I am the original author of the submission at this URL / this text.
+      error:
+        banned_domain: "The submission is from a banned domain: %{domain}"
+        title_missing: Please ensure you provide a helpful title within 10 and 175 characters long.
+        title_length: Title must be between 10 and 175 characters long.
+        url_exists: Woops! It looks like there is already a submission for this URL!
+        url_health: >-
+          The URL you submitted failed our health checks. Please ensure you've specified the URL
+          scheme (http / https) and that the website is up and accepting connections. If the problem
+          persists please contact our mod team.
+        url_or_body: You must specify a URL or body, but not both. If you submit a URL, put your description in the comments.

--- a/config/locales/url.en.yml
+++ b/config/locales/url.en.yml
@@ -1,5 +1,5 @@
 en:
   url:
     error:
-      scheme: "unaccepted URL scheme: %{scheme}"
+      scheme: "unaccepted URL scheme: %{scheme}. Must be http or https (and make sure it's prepended to your URL!)"
       invalid: "invalid URL: %{url}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
 
   root to: "submissions#index"
 
-  resources :submissions, only: [:index, :show]
+  resources :submissions, only: [:index, :show, :new, :create]
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,7 @@
 const { environment } = require('@rails/webpacker')
 
+environment.loaders.get('sass').use.splice(-1, 0, {
+  loader: 'resolve-url-loader'
+});
+
 module.exports = environment

--- a/db/migrate/20200515043324_add_partial_index_to_url_on_submissions.rb
+++ b/db/migrate/20200515043324_add_partial_index_to_url_on_submissions.rb
@@ -1,0 +1,5 @@
+class AddPartialIndexToUrlOnSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_index :submissions, :url, unique: true, where: "url IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_030843) do
+ActiveRecord::Schema.define(version: 2020_05_15_043324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2020_05_12_030843) do
     t.boolean "original_author", default: false, null: false
     t.bigint "domain_id"
     t.index ["domain_id"], name: "index_submissions_on_domain_id", where: "(domain_id IS NOT NULL)"
+    t.index ["url"], name: "index_submissions_on_url", unique: true, where: "(url IS NOT NULL)"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "katex": "^0.11.1",
+    "resolve-url-loader": "^3.1.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/spec/factories/domains.rb
+++ b/spec/factories/domains.rb
@@ -4,5 +4,17 @@ FactoryBot.define do
     tracker { false }
     banned_at { nil }
     banned_by { nil }
+
+    trait :banned do
+      transient do
+        banned_at { Time.zone.now }
+        banned_by { build(:user) }
+      end
+
+      after(:build) do |domain, evaluator|
+        domain.banned_at = evaluator.banned_at
+        domain.banned_by = evaluator.banned_by
+      end
+    end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,10 +1,19 @@
 FactoryBot.define do
   factory :submission do
-    sequence(:title) { |n| "A Very Useful Title #{n}" }
-    sequence(:url) { |n| "https://www.somesite#{n}.com/path/to/content" }
-    body { nil }
     user
+    sequence(:title) { |n| "A Very Useful Title #{n}" }
     original_author { false }
-    domain
+  end
+
+  trait :url do
+    sequence(:url) { |n| "https://www.somesite#{n}.com/path/to/content" }
+    domain { build(:domain, name: URI.parse(url).host) }
+    body { nil }
+  end
+
+  trait :text do
+    url { nil }
+    domain { nil }
+    body { "A very useful text body" }
   end
 end

--- a/spec/form_objects/create_submission_form_spec.rb
+++ b/spec/form_objects/create_submission_form_spec.rb
@@ -1,0 +1,264 @@
+RSpec.describe CreateSubmissionForm do
+  include UrlHelpers
+
+  let(:user) { create(:user) }
+  let(:i18n_error_prefix) { CreateSubmissionForm::I18N_PREFIX }
+
+  describe "#save" do
+    # we can probably do some more validations on this but
+    # for now making a text submission is pretty easy.
+    context "when the submission is a text submission" do
+      context "when the submission is valid" do
+        it "persists the submission" do
+          params = { title: "Foo bar biz", body: "abcd1234", original_author: "1" }
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).to be_persisted
+
+          expect(submission.title).to eq("Foo bar biz")
+          expect(submission.body).to eq("abcd1234")
+          expect(submission).to be_original_author
+        end
+      end
+    end
+
+    context "when the submission involves a URL and is valid" do
+      context "when the domain has not been seen before" do
+        it "creates a new submission record and domain record" do
+          url = "http://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url)
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+          domain = Domain.find_by(name: "foobar.com")
+
+          # make sure domain got created
+          expect(Domain.count).to eq(1)
+          expect(domain).to be_a(Domain)
+          expect(submission).to be_persisted
+          expect(submission.title).to eq("Foo to the bar, biz, and baz")
+          expect(submission.url).to eq("http://foobar.com")
+          expect(submission.domain).to eq(domain)
+          expect(submission.body).to be_nil
+          expect(submission).not_to be_original_author
+          expect(submission.user).to eq(user)
+        end
+      end
+
+      context "when there is an existing record for the domain" do
+        it "assigns the submission the existing domain record and saves the submission" do
+          url = "http://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url)
+          domain = create(:domain, name: "foobar.com")
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(Domain.count).to eq(1)
+          expect(submission).to be_persisted
+          expect(submission.title).to eq("Foo to the bar, biz, and baz")
+          expect(submission.url).to eq("http://foobar.com")
+          expect(submission.domain).to eq(domain)
+          expect(submission.body).to be_nil
+          expect(submission.original_author).to eq(false)
+          expect(submission.user).to eq(user)
+        end
+      end
+    end
+
+    context "when the submission involves a URL and is not valid" do
+      context "when the domain is banned" do
+        it "adds a domain error and does not persist the submission" do
+          url = "http://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url)
+          domain = create(:domain, :banned, name: "foobar.com")
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:domain]).
+            to include(I18n.t("#{i18n_error_prefix}.banned_domain", domain: domain.name))
+        end
+      end
+
+      # i.e. URL A gets redirected to URL B, which is banned
+      # maybe someone tried to pull a fast one, or didn't know.
+      context "when the redirected domain is banned" do
+        it "adds a domain error and does not persist the submission" do
+          url = "http://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url, ending_url: "http://barfoo.com")
+          domain = create(:domain, :banned, name: "barfoo.com")
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:domain]).
+            to include(I18n.t("#{i18n_error_prefix}.banned_domain", domain: domain.name))
+        end
+      end
+
+      context "when the URL fails health checks" do
+        it "adds a url health error and does not persist the submission" do
+          url = "http://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url, healthy: false)
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:url]).to include(I18n.t("#{i18n_error_prefix}.url_health"))
+        end
+      end
+
+      context "when there is an issue with the URL itself" do
+        it "adds a url error when the URL scheme is not http or https and does not persist submission" do
+          url = "htt://foobar.com"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:url]).to include(I18n.t("url.error.scheme", scheme: "htt"))
+        end
+
+        # I would ask when this would ever happen but users never surprise me
+        it "adds a url error when the URL doesn't have a host and does not persist the submission" do
+          url = "http://"
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:url]).to include(I18n.t("url.error.invalid", url: url))
+        end
+      end
+
+      context "when the URL has already been submitted" do
+        it "does not persist the submission and adds an error to the error list" do
+          url = "http://foobar.com"
+          create(:submission, :url, url: url)
+          params = { title: "Foo to the bar, biz, and baz", url: url }
+          stub_url_health_check(url)
+
+          form = CreateSubmissionForm.new(params, user)
+
+          form.save
+
+          submission = form.submission
+
+          expect(submission).not_to be_persisted
+          expect(form.errors[:url]).to include(I18n.t("#{i18n_error_prefix}.url_exists"))
+        end
+      end
+    end
+
+    context "when there is both a URL and a submission body" do
+      it "adds a base error and does not persist the submission" do
+        url = "http://foobar.com"
+        params = { title: "Foo to the bar, biz, and baz", url: url, body: "abcd12323423234" }
+        stub_url_health_check(url)
+
+        form = CreateSubmissionForm.new(params, user)
+
+        form.save
+
+        submission = form.submission
+
+        expect(submission).not_to be_persisted
+        expect(form.errors[:base]).to include(I18n.t("#{i18n_error_prefix}.url_or_body"))
+      end
+    end
+
+    context "when the title is missing" do
+      it "adds an error and doesn't persist the submission" do
+        url = "http://foobar.com"
+        params = { body: "abcd12323423234" }
+        stub_url_health_check(url)
+
+        form = CreateSubmissionForm.new(params, user)
+
+        form.save
+
+        submission = form.submission
+
+        expect(submission).not_to be_persisted
+        expect(form.errors[:title]).to include(
+          I18n.t("#{i18n_error_prefix}.title_missing")
+        )
+      end
+    end
+
+    context "when the title is too short" do
+      it "adds an error and doesn't persist the submission" do
+        url = "http://foobar.com"
+        params = { title: "abc", body: "abcd12323423234" }
+        stub_url_health_check(url)
+
+        form = CreateSubmissionForm.new(params, user)
+
+        form.save
+
+        submission = form.submission
+
+        expect(submission).not_to be_persisted
+        expect(form.errors[:title]).to include(
+          I18n.t("#{i18n_error_prefix}.title_length")
+        )
+      end
+    end
+
+    context "when the title is too long" do
+      it "adds an error and doesn't persist the submission" do
+        url = "http://foobar.com"
+        params = { title: ("abc" * 100), body: "abcd12323423234" }
+        stub_url_health_check(url)
+
+        form = CreateSubmissionForm.new(params, user)
+
+        form.save
+
+        submission = form.submission
+
+        expect(submission).not_to be_persisted
+        expect(form.errors[:title]).to include(
+          I18n.t("#{i18n_error_prefix}.title_length")
+        )
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/create_submission_page.rb
+++ b/spec/support/page_objects/create_submission_page.rb
@@ -1,0 +1,72 @@
+require "support/page_objects/page_base"
+
+class CreateSubmissionPage < PageBase
+  def visit(as:)
+    login_as(as) if as.present?
+    super(new_submission_path)
+    self
+  end
+
+  def fill_in_title(str)
+    fill_in :create_submission_form_title, with: str
+    self
+  end
+
+  def fill_in_url(str)
+    fill_in :create_submission_form_url, with: str
+    self
+  end
+
+  def fill_in_body(str)
+    fill_in :create_submission_form_body, with: str
+    self
+  end
+
+  def check_original_author
+    check :create_submission_form_original_author
+    self
+  end
+
+  def submit_form
+    click_on t("helpers.submit.create_submission_form.create")
+    self
+  end
+
+  def has_title_missing_error?
+    has_error?(t("submissions.new.error.title_missing"))
+  end
+
+  def has_title_length_error?
+    has_error?(t("submissions.new.error.title_length"))
+  end
+
+  def has_url_xor_body_error?
+    has_error?(t("submissions.new.error.url_or_body"))
+  end
+
+  def has_banned_domain_error?(domain)
+    has_error?(t("submissions.new.error.banned_domain", domain: domain))
+  end
+
+  def has_invalid_url_error?(url)
+    has_error?(t("url.error.invalid", url: url))
+  end
+
+  def has_invalid_url_scheme_error?(scheme)
+    has_error?(t("url.error.scheme", scheme: scheme))
+  end
+
+  def has_url_health_error?
+    has_error?(t("submissions.new.error.url_health"))
+  end
+
+  def has_existing_submission_for_url_error?
+    has_error?(t("submissions.new.error.url_exists"))
+  end
+
+  def has_error?(error)
+    within find(".errors") do
+      has_css?("li.error", text: error)
+    end
+  end
+end

--- a/spec/support/page_objects/view_submission_page.rb
+++ b/spec/support/page_objects/view_submission_page.rb
@@ -1,0 +1,37 @@
+require "support/page_objects/page_base"
+
+class ViewSubmissionPage < PageBase
+  def visit(submission, as:)
+    login_as(as) if as.present?
+    super(submission_path(submission.id))
+    self
+  end
+
+  def has_correct_submission_link?(submission)
+    url = submission.url.presence || submission_path(submission.id)
+
+    within find(".submission-link") do
+      has_link?(submission.title, href: url)
+    end
+  end
+
+  def has_authored_by?(user)
+    within find(".submission-line2") do
+      has_css?(".submission-info", text: t("submissions.submission_list_item.authored_by")) &&
+        has_css?(".submission-user a", text: user.username)
+    end
+  end
+
+  def has_submitted_by?(user)
+    within find(".submission-line2") do
+      has_css?(".submission-info", text: t("submissions.submission_list_item.submitted_by")) &&
+        has_css?(".submission-user a", text: user.username)
+    end
+  end
+
+  def has_plain_text_submission_body?(body)
+    within find(".submission-body") do
+      has_css?("p", text: body)
+    end
+  end
+end

--- a/spec/support/url_helpers.rb
+++ b/spec/support/url_helpers.rb
@@ -1,0 +1,11 @@
+module UrlHelpers
+  def stub_url_health_check(url, healthy: true, ending_url: nil)
+    uri = URI.parse(url)
+    service = UrlHealthCheckService.new(uri)
+    allow(UrlHealthCheckService).to receive(:new).with(uri).and_return(service)
+    allow(service).to receive(:healthy?).and_return(healthy)
+    if ending_url.present?
+      allow(service).to receive(:ending_uri).and_return(URI.parse(ending_url))
+    end
+  end
+end

--- a/spec/system/user_makes_submission_spec.rb
+++ b/spec/system/user_makes_submission_spec.rb
@@ -1,0 +1,222 @@
+RSpec.describe "user makes a submission" do
+  include UrlHelpers
+
+  let(:page) { CreateSubmissionPage.new }
+
+  context "when the user is not signed in" do
+    it "redirects the user to the login page" do
+      # no user context
+      page.visit(as: nil)
+
+      # kind of a weird way to test this but there isn't a good
+      # way to do it otherwise in a system spec.
+      expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+
+  context "when the user is signed in" do
+    let(:user) { create(:user) }
+
+    context "when the submission is for a URL" do
+      it "creates the submission and redirects the user to the submission's view if successful" do
+        url = "https://foo.com"
+        stub_url_health_check(url)
+
+        page.visit(as: user).
+          fill_in_title("A Very Nice Title").
+          fill_in_url(url).
+          check_original_author.
+          submit_form
+
+        submission = Submission.first
+
+        expect(Submission.count).to eq(1)
+        expect(page).to have_current_path(submission_path(submission.id))
+        expect(submission.title).to eq("A Very Nice Title")
+        expect(submission.url).to eq(url)
+        expect(submission.body).to be_nil
+        expect(submission.original_author).to eq(true)
+      end
+
+      # i.e for redirects
+      it "updates the URL to the final URL if it doesn't match the original" do
+        url = "https://foo.com"
+        stub_url_health_check(url, ending_url: "https://bar.foo.com")
+
+        page.visit(as: user).
+          fill_in_title("A Very Nice Title").
+          fill_in_url(url).
+          check_original_author.
+          submit_form
+
+        submission = Submission.first
+
+        expect(Submission.count).to eq(1)
+        expect(page).to have_current_path(submission_path(submission.id))
+        expect(submission.title).to eq("A Very Nice Title")
+        expect(submission.url).to eq("https://bar.foo.com")
+        expect(submission.body).to be_nil
+        expect(submission.original_author).to eq(true)
+      end
+
+      context "when the URL is malformed" do
+        it "displays an error at the top of the page and doesn't save the submission" do
+          create(:domain, :banned, name: "foo.com")
+          url = "https:/foo.com/biz/baz"
+          page.visit(as: user).
+            fill_in_title("A Very Nice Title").
+            fill_in_url(url).
+            check_original_author.
+            submit_form
+
+          expect(Submission.count).to eq(0)
+          expect(page).to have_invalid_url_error(url)
+        end
+      end
+
+      context "when the URL scheme isn't HTTP or HTTPS" do
+        it "displays an error at the top of the page and doesn't save the submission" do
+          create(:domain, :banned, name: "foo.com")
+          url = "ftp://foo@ftp.foo.com/biz/baz"
+          page.visit(as: user).
+            fill_in_title("A Very Nice Title").
+            fill_in_url(url).
+            check_original_author.
+            submit_form
+
+          expect(Submission.count).to eq(0)
+          expect(page).to have_invalid_url_scheme_error("ftp")
+        end
+      end
+
+      context "when the domain is banned" do
+        it "displays an error at the top of the page and doesn't save the submission" do
+          create(:domain, :banned, name: "foo.com")
+          page.visit(as: user).
+            fill_in_title("A Very Nice Title").
+            fill_in_url("https://www.foo.com/biz/baz").
+            check_original_author.
+            submit_form
+
+          expect(Submission.count).to eq(0)
+          expect(page).to have_banned_domain_error("foo.com")
+        end
+      end
+
+      context "when the URL healthcheck fails" do
+        it "displays an error at the top of the page and doesn't save the submission" do
+          url = "https://foo.com"
+          stub_url_health_check(url, healthy: false)
+
+          page.visit(as: user).
+            fill_in_title("A Very Nice Title").
+            fill_in_url(url).
+            check_original_author.
+            submit_form
+
+          expect(Submission.count).to eq(0)
+          expect(page).to have_url_health_error
+        end
+      end
+
+      context "when as submission already exists for the URL" do
+        it "displays an error at the top of the page and doesn't save the submission" do
+          url = "https://foo.com"
+          create(:submission, url: url)
+          stub_url_health_check(url)
+
+          page.visit(as: user).
+            fill_in_title("A Very Nice Title").
+            fill_in_url(url).
+            check_original_author.
+            submit_form
+
+          expect(Submission.count).to eq(1)
+          expect(page).to have_existing_submission_for_url_error
+        end
+      end
+    end
+
+    context "when the submission is a text submission" do
+      it "creates the submission and redirects the user to the submission's view if successful" do
+        page.visit(as: user).
+          fill_in_title("A Very Nice Title").
+          fill_in_body("This is a very nice submission body").
+          check_original_author.
+          submit_form
+
+        submission = Submission.first
+
+        expect(Submission.count).to eq(1)
+        expect(page).to have_current_path(submission_path(submission.id))
+        expect(submission.title).to eq("A Very Nice Title")
+        expect(submission.url).to be_nil
+        expect(submission.body).to eq("This is a very nice submission body")
+        expect(submission.original_author).to eq(true)
+      end
+    end
+
+    context "when the title is missing" do
+      it "displays an error at the top of the page and doesn't save the submission" do
+        page.visit(as: user).
+          fill_in_body("This is a very nice submission body with some great info").
+          check_original_author.
+          submit_form
+
+        expect(Submission.count).to eq(0)
+        expect(page).to have_title_missing_error
+      end
+    end
+
+    context "when the title is too short" do
+      it "displays an error at the top of the page and doesn't save the submission" do
+        page.visit(as: user).
+          fill_in_title("tooshort").
+          fill_in_body("This is a very nice submission body with some great info").
+          check_original_author.
+          submit_form
+
+        expect(Submission.count).to eq(0)
+        expect(page).to have_title_length_error
+      end
+    end
+
+    context "when the title is too long" do
+      it "displays an error at the top of the page and doesn't save the submission" do
+        page.visit(as: user).
+          fill_in_title("f" * 176).
+          fill_in_body("This is a very nice submission body with some great info").
+          check_original_author.
+          submit_form
+
+        expect(Submission.count).to eq(0)
+        expect(page).to have_title_length_error
+      end
+    end
+
+    context "when both the URL and body are missing" do
+      it "displays an error at the top of the page and doesn't save the submission" do
+        page.visit(as: user).
+          check_original_author.
+          submit_form
+
+        expect(Submission.count).to eq(0)
+        expect(page).to have_url_xor_body_error
+      end
+    end
+
+    context "when both the URL and body are present" do
+      it "displays an error at the top of the page and doesn't save the submission" do
+        page.visit(as: user).
+          fill_in_title("a very nice ticle").
+          fill_in_body("lalalal la la laalla la").
+          fill_in_url("https://www.url.com").
+          check_original_author.
+          submit_form
+
+        expect(Submission.count).to eq(0)
+        expect(page).to have_url_xor_body_error
+      end
+    end
+  end
+end

--- a/spec/system/user_views_submission_spec.rb
+++ b/spec/system/user_views_submission_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe "user views submission" do
+  let(:user) { create(:user) }
+
+  context "when the submitter is the original author" do
+    it "shows that the submitter is the author" do
+      submission = create(:submission, :url, original_author: true)
+
+      page = ViewSubmissionPage.new
+
+      page.visit(submission, as: user)
+
+      expect(page).to have_authored_by(submission.user)
+    end
+  end
+
+  context "when the submitter is not the original author" do
+    it "does not state that the submitter is the original author" do
+      submission = create(:submission, :url, original_author: false)
+
+      page = ViewSubmissionPage.new
+
+      page.visit(submission, as: user)
+
+      expect(page).to have_submitted_by(submission.user)
+    end
+  end
+
+  context "when the submission is for a URL" do
+    it "displays the submission information and links to the external URL" do
+      submission = create(:submission, :url)
+
+      page = ViewSubmissionPage.new
+
+      page.visit(submission, as: user)
+
+      expect(page).to have_correct_submission_link(submission)
+    end
+  end
+
+  context "when the submission is a text submission" do
+    it "displays the submission information and body, and links to itself" do
+      submission = create(:submission, :text)
+
+      page = ViewSubmissionPage.new
+
+      page.visit(submission, as: user)
+
+      expect(page).to have_correct_submission_link(submission)
+      expect(page).to have_plain_text_submission_body(submission.body)
+    end
+
+    context "when there is markdown in the submission body" do
+      it "displays the markdown formatted submission body" do
+        body = "# A markdown header\n- items\n- in\n-a\n- list\n```\ncode block\n```"
+        submission = create(:submission, :text, body: body)
+
+        page = ViewSubmissionPage.new
+
+        page.visit(submission, as: user)
+
+        within find(".submission-body") do
+          expect(page).to have_css("h1", text: "A markdown header")
+          within find("ul") do
+            expect(page).to have_css("li", text: "items")
+            expect(page).to have_css("li", text: "in")
+            expect(page).to have_css("li", text: "a")
+            expect(page).to have_css("li", text: "list")
+          end
+          expect(page).to have_css("pre code", text: "code block")
+        end
+      end
+    end
+
+    context "when there is LaTeX in the submission body (oh boy)", js: true do
+      # I'm not going to test every little thing here given that the
+      # katex library itself should take care of making sure that it
+      # works as advertised.
+      it "displays the LaTeX in katex nodes within the body" do
+        body = "\\(f(x)=x^2\\)\n$$g(x)=x^3$$\n\\[h(x)=x^4\\]"
+        submission = create(:submission, :text, body: body)
+
+        page = ViewSubmissionPage.new
+
+        page.visit(submission, as: user)
+
+        within find(".submission-body") do
+          expect(page).to have_css(".katex .katex-mathml") # inline display
+          expect(page.all(:css, ".katex-display").length).to eq(2) # should be two display mode renderings
+        end
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,17 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
+adjust-sourcemap-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz#6471143af75ec02334b219f54bc7970c52fb29a4"
+  integrity sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==
+  dependencies:
+    assert "1.4.1"
+    camelcase "5.0.0"
+    loader-utils "1.2.3"
+    object-path "0.11.4"
+    regex-parser "2.2.10"
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -1144,6 +1155,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arity-n@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
+  integrity sha1-2edrEXM+CFacCEeuezmyhgswt0U=
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1211,6 +1227,13 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
+assert@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
+  dependencies:
+    util "0.10.3"
 
 assert@^1.1.1:
   version "1.5.0"
@@ -1644,15 +1667,20 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
-
-camelcase@^5.0.0, camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -1833,7 +1861,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1847,6 +1875,13 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compose-function@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
+  integrity sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=
+  dependencies:
+    arity-n "^1.0.4"
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -1927,12 +1962,17 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.7.0:
+convert-source-map@1.7.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
+
+convert-source-map@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
+  integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -2157,6 +2197,16 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
 
+css@^2.0.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssdb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
@@ -2258,6 +2308,14 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2595,6 +2653,32 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.50:
+  version "0.10.53"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
+  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.3"
+    next-tick "~1.0.0"
+
+es6-iterator@2.0.3, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2733,6 +2817,13 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
+  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
+  dependencies:
+    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -3918,6 +4009,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+katex@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
+  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
+  dependencies:
+    commander "^2.19.0"
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -4461,6 +4559,11 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+next-tick@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -4665,6 +4768,11 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-path@0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5724,6 +5832,15 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss@7.0.21:
+  version "7.0.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
+  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.29"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.29.tgz#d3a903872bd52280b83bce38cdc83ce55c06129e"
@@ -5997,6 +6114,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regex-parser@2.2.10:
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
+  integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
+
 regexp.prototype.flags@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -6117,6 +6239,22 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-url-loader@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz#28931895fa1eab9be0647d3b2958c100ae3c0bf0"
+  integrity sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==
+  dependencies:
+    adjust-sourcemap-loader "2.0.0"
+    camelcase "5.3.1"
+    compose-function "3.0.3"
+    convert-source-map "1.7.0"
+    es6-iterator "2.0.3"
+    loader-utils "1.2.3"
+    postcss "7.0.21"
+    rework "1.0.1"
+    rework-visit "1.0.0"
+    source-map "0.6.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6138,6 +6276,19 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
+rework-visit@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a"
+  integrity sha1-mUWygD8hni96ygCtuLyfZA+ELJo=
+
+rework@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7"
+  integrity sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=
+  dependencies:
+    convert-source-map "^0.3.3"
+    css "^2.0.0"
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -6460,7 +6611,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -6484,6 +6635,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -6495,11 +6651,6 @@ source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spark-md5@^3.0.0:
   version "3.0.1"
@@ -7012,6 +7163,16 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
+  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This commit adds the ability for users to create submissions
  as well as view existing submissions.

It includes (naive) support for both markdown and LaTeX.

The way we process the submission bodies for display should
  probably be thoroughly QA'd to make sure we're not doing
  anything insane.

I opted to format the markdown at render time due to the fact
  that certain markdown elements requre a large number of
  HTML tags to render, and this incurrs an additional storage
  cost for the submission body. If this becomes an issue in the
  future we can look into caching the markdown html somewhere.