### PR TITLE
adds ability for users to tag submissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,9 @@ Naming/PredicateName:
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
 Naming/MethodParameterName:
   Enabled: false
 

--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -13,11 +13,18 @@
     }
   }
   .submission-line1 {
+    position: relative;
     .submission-link a {
       text-decoration: none;
       font-size: 1.2rem;
       font-weight: $font-weight-bold;
       margin-right: $spacing-xs;
+    }
+    .submission-tags {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      margin-left: $spacing-xs;
     }
   }
   .submission-line2 {
@@ -36,6 +43,17 @@
       a {
         text-decoration: none;
       }
+    }
+  }
+}
+
+// Tinyyy screens
+@media only screen and (max-width: 400px) {
+  .submission-line1 {
+    position: static !important;
+    .submission-tags {
+      position: static !important;
+      margin-left: auto !important;
     }
   }
 }

--- a/app/assets/stylesheets/shared/_shared.scss
+++ b/app/assets/stylesheets/shared/_shared.scss
@@ -1,3 +1,4 @@
 @import "navbar";
 @import "simple_form";
 @import "pagination";
+@import "tags";

--- a/app/assets/stylesheets/shared/_tags.scss
+++ b/app/assets/stylesheets/shared/_tags.scss
@@ -1,0 +1,43 @@
+.tag {
+  text-decoration: none;
+  border-radius: 0.25rem;
+  padding: 0.15rem;
+  font-size: 65%;
+  vertical-align: middle;
+}
+
+@mixin tag($color) {
+  background-color: $color;
+  border: 1px solid darken($color, 40%);
+  color: darken($color, 60%);
+  transition: color $transition;
+  transition: background-color $transition;
+  &:hover {
+    background-color: lighten($color, 10%);
+    color: darken($color, 50%);
+  }
+  &:active {
+    background-color: darken($color, 10%);
+    color: darken($color, 80%);
+  }
+}
+
+.tag_topic {
+  @include tag(#ceecfd);
+}
+
+.tag_media {
+  @include tag(#d9c7f2);
+}
+
+.tag_source {
+  @include tag(#f7f5a8);
+}
+
+.tag_meta {
+  @include tag(#c7f2cd);
+}
+
+.tag_mod {
+  @include tag(#ff8f8f);
+}

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -25,7 +25,8 @@ class SubmissionsController < ApplicationController
   private
 
   def create_submission_params
-    params.require(:create_submission_form).permit(:url, :title, :body, :original_author)
+    params.require(:create_submission_form).
+      permit(:url, :title, :body, :original_author, tag_ids: [])
   end
 
   def submission_search_params

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -14,4 +14,10 @@ module SubmissionsHelper
   def submitted_time_text(submission)
     "#{time_ago_in_words(submission.created_at)} #{t('submissions.submission_list_item.ago')}"
   end
+
+  def tag_select_options(user)
+    Tag.for_user(user).order(:id).all.map do |tag|
+      [tag.id, tag.id]
+    end
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -3,4 +3,6 @@ class Submission < ApplicationRecord
 
   belongs_to :user
   belongs_to :domain, optional: true
+  has_many :submission_tags
+  has_many :tags, through: :submission_tags
 end

--- a/app/models/submission_tag.rb
+++ b/app/models/submission_tag.rb
@@ -1,0 +1,4 @@
+class SubmissionTag < ApplicationRecord
+  belongs_to :submission
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,20 @@
+class Tag < ApplicationRecord
+  enum kind: {
+    topic: 0,
+    media: 5,
+    source: 10,
+    meta: 15,
+    mod: 20
+  }
+
+  has_many :submission_tags
+  has_many :submissions, through: :submission_tags
+
+  def self.for_user(user)
+    if user.moderator? || user.admin?
+      Tag.all
+    else
+      Tag.where.not(kind: :mod)
+    end
+  end
+end

--- a/app/views/shared/_tag.html.haml
+++ b/app/views/shared/_tag.html.haml
@@ -1,0 +1,1 @@
+%a{ href: "#", class: "tag tag_#{tag.kind}", title: tag.description }= tag.id

--- a/app/views/submissions/_submission_list_item.html.haml
+++ b/app/views/submissions/_submission_list_item.html.haml
@@ -1,6 +1,9 @@
 .submission{ id: "submission_#{submission.id}" }
   .submission-line1
     %span.submission-link= link_to(submission.title, submission_href_for(submission))
+    %span.submission-tags
+      - submission.tags.each do |tag|
+        = render "shared/tag", tag: tag
     %span.submission-info
       %i= submission.domain.name if submission.domain.present?
   .submission-line2

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -5,6 +5,8 @@
 = simple_form_for @form, url: submissions_path do |f|
   = f.input :url
   = f.input :title
+  = f.input :tag_ids, collection: tag_select_options(current_user),
+    input_html: { multiple: true, id: "tag-select" }
   = f.input :body, as: :text, input_html: { rows: 15 }
   .original-author-statement
     = f.input :original_author, as: :boolean, wrapper: :left_hand_label

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -5,4 +5,5 @@ en:
         url: "URL"
         title: "Title"
         body: "Body"
+        tag_ids: "Tags (choose up to 5)"
         original_author: "Original author:"

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -14,6 +14,10 @@ en:
         banned_domain: "The submission is from a banned domain: %{domain}"
         title_missing: Please ensure you provide a helpful title between 10 and 175 characters long.
         title_length: Title must be between 10 and 175 characters long.
+        tags_missing: You must select at least one tag for your submission.
+        tags_max: You may only select up to 5 tags.
+        tag_forbidden: You attempted to apply a tag that you don't have access to.
+        tag_media: You must select at least one non-media tag.
         url_exists: Woops! It looks like there is already a submission for this URL!
         url_health: >-
           The URL you submitted failed our health checks. Please ensure you've specified the URL

--- a/db/migrate/20200515180402_create_tags.rb
+++ b/db/migrate/20200515180402_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags, id: :string do |t|
+      t.string :description, limit: 100
+      t.integer :kind, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200515182627_create_submission_tags.rb
+++ b/db/migrate/20200515182627_create_submission_tags.rb
@@ -1,0 +1,10 @@
+class CreateSubmissionTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submission_tags do |t|
+      t.belongs_to :submission, null: false, foreign_key: { on_delete: :cascade }
+      t.belongs_to :tag, null: false, type: :text, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2020_05_16_200636) do
     t.index ["name"], name: "index_domains_on_name", unique: true
   end
 
+  create_table "submission_tags", force: :cascade do |t|
+    t.bigint "submission_id", null: false
+    t.text "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["submission_id"], name: "index_submission_tags_on_submission_id"
+    t.index ["tag_id"], name: "index_submission_tags_on_tag_id"
+  end
+
   create_table "submissions", force: :cascade do |t|
     t.string "title", limit: 175, null: false
     t.string "url"
@@ -40,6 +49,13 @@ ActiveRecord::Schema.define(version: 2020_05_16_200636) do
     t.index ["short_id"], name: "index_submissions_on_short_id", unique: true
     t.index ["url"], name: "index_submissions_on_url", unique: true, where: "(url IS NOT NULL)"
     t.index ["user_id"], name: "index_submissions_on_user_id"
+  end
+
+  create_table "tags", id: :string, force: :cascade do |t|
+    t.string "description", limit: 100
+    t.integer "kind", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -69,6 +85,8 @@ ActiveRecord::Schema.define(version: 2020_05_16_200636) do
   end
 
   add_foreign_key "domains", "users", column: "banned_by_id"
+  add_foreign_key "submission_tags", "submissions", on_delete: :cascade
+  add_foreign_key "submission_tags", "tags", on_delete: :cascade
   add_foreign_key "submissions", "domains"
   add_foreign_key "submissions", "users"
 end

--- a/spec/factories/submission_tags.rb
+++ b/spec/factories/submission_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :submission_tag do
+    submission
+    tag
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -16,4 +16,12 @@ FactoryBot.define do
     domain { nil }
     body { "A very useful text body" }
   end
+
+  trait :with_all_tags do
+    after(:build) do |submission|
+      Tag.kinds.keys.each do |kind|
+        submission.tags << build(:"#{kind}_tag")
+      end
+    end
+  end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  factory :tag do
+    factory :topic_tag do
+      sequence(:id) { |n| "topic-tag-#{n}" }
+      sequence(:description) { |n| "topic tag description #{n}" }
+      kind { :topic }
+    end
+
+    factory :media_tag do
+      sequence(:id) { |n| "media-tag-#{n}" }
+      sequence(:description) { |n| "media tag description #{n}" }
+      kind { :media }
+    end
+
+    factory :source_tag do
+      sequence(:id) { |n| "source-tag-#{n}" }
+      sequence(:description) { |n| "source tag description #{n}" }
+      kind { :source }
+    end
+
+    factory :meta_tag do
+      sequence(:id) { |n| "meta-tag-#{n}" }
+      sequence(:description) { |n| "meta tag description #{n}" }
+      kind { :meta }
+    end
+
+    factory :mod_tag do
+      sequence(:id) { |n| "mod-tag-#{n}" }
+      sequence(:description) { |n| "mod tag description #{n}" }
+      kind { :mod }
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Submission, type: :model do
   it { should belong_to(:user) }
   it { should belong_to(:domain).optional }
+  it { should have_many(:submission_tags) }
+  it { should have_many(:tags).through(:submission_tags) }
 
   describe "#before_create" do
     it "sets its short id" do

--- a/spec/models/submission_tag_spec.rb
+++ b/spec/models/submission_tag_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe SubmissionTag, type: :model do
+  it { should belong_to(:submission) }
+  it { should belong_to(:tag) }
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Tag, type: :model do
+  it { should have_many(:submission_tags) }
+  it { should have_many(:submissions).through(:submission_tags) }
+
+  describe ".for_user" do
+    let!(:topic_tag) { create(:topic_tag) }
+    let!(:media_tag) { create(:media_tag) }
+    let!(:source_tag) { create(:source_tag) }
+    let!(:meta_tag) { create(:meta_tag) }
+    let(:mod_tag) { create(:mod_tag) }
+
+    context "when the user is an admin" do
+      it "returns all the tags" do
+        user = create(:user, :admin)
+
+        expect(Tag.for_user(user)).to eq([topic_tag, media_tag, source_tag, meta_tag, mod_tag])
+      end
+    end
+
+    context "when the user is a moderator" do
+      it "returns all the tags" do
+        user = create(:user, :moderator)
+
+        expect(Tag.for_user(user)).to eq([topic_tag, media_tag, source_tag, meta_tag, mod_tag])
+      end
+    end
+
+    context "when the user is a member" do
+      it "returns all the tags except mod tags" do
+        user = create(:user)
+
+        expect(Tag.for_user(user)).to eq([topic_tag, media_tag, source_tag, meta_tag])
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/create_submission_page.rb
+++ b/spec/support/page_objects/create_submission_page.rb
@@ -17,6 +17,11 @@ class CreateSubmissionPage < PageBase
     self
   end
 
+  def select_tag(tag_name)
+    select tag_name, from: t("simple_form.labels.create_submission_form.tag_ids")
+    self
+  end
+
   def fill_in_body(str)
     fill_in :create_submission_form_body, with: str
     self
@@ -44,6 +49,18 @@ class CreateSubmissionPage < PageBase
 
   def has_url_xor_body_error?
     has_error?(t("submissions.new.error.url_or_body"))
+  end
+
+  def has_missing_tags_error?
+    has_error?(t("submissions.new.error.tags_missing"))
+  end
+
+  def has_tags_max_error?
+    has_error?(t("submissions.new.error.tags_max"))
+  end
+
+  def has_tag_media_error?
+    has_error?(t("submissions.new.error.tag_media"))
   end
 
   def has_banned_domain_error?(domain)

--- a/spec/support/page_objects/submissions_index_page.rb
+++ b/spec/support/page_objects/submissions_index_page.rb
@@ -18,7 +18,8 @@ class SubmissionsIndexPage < PageBase
   def has_correct_submission_info?(submission)
     within find("#submission_#{submission.id}") do
       has_proper_submission_link?(submission) &&
-        has_css?(".submission-user", text: submission.user.username)
+        has_css?(".submission-user", text: submission.user.username) &&
+        has_submission_tags?(submission)
     end
   end
 
@@ -26,5 +27,11 @@ class SubmissionsIndexPage < PageBase
     url = submission.url.presence || submission_path(submission.short_id)
 
     has_link?(submission.title, href: url)
+  end
+
+  def has_submission_tags?(submission)
+    submission.tags.each do |tag|
+      has_css?(".tag_#{tag.kind}", text: tag.id)
+    end
   end
 end

--- a/spec/support/page_objects/view_submission_page.rb
+++ b/spec/support/page_objects/view_submission_page.rb
@@ -34,4 +34,8 @@ class ViewSubmissionPage < PageBase
       has_css?("p", text: body)
     end
   end
+
+  def has_tag?(tag)
+    has_css?(".tag_#{tag.kind}", text: tag.id)
+  end
 end

--- a/spec/system/submissions_index_spec.rb
+++ b/spec/system/submissions_index_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "submissions index" do
   context "when a user visits the submission index" do
     it "can view a list of submissions in descending order by default" do
-      submissions = create_pair(:submission)
+      submissions = create_pair(:submission, :with_all_tags)
       page = SubmissionsIndexPage.new
 
       page.visit
@@ -25,7 +25,7 @@ RSpec.describe "submissions index" do
         # to get it to page, so we'll do this for now.
         # Open to better ways to do it.
         stub_const("SubmissionSearch::DEFAULT_PER_PAGE", 2)
-        s1, s2, s3, s4, s5 = create_list(:submission, 5)
+        s1, s2, s3, s4, s5 = create_list(:submission, 5, :with_all_tags)
         page = SubmissionsIndexPage.new
 
         page.visit
@@ -66,7 +66,7 @@ RSpec.describe "submissions index" do
 
     context "when there is only one page" do
       it "there are no paging controls" do
-        submission = create(:submission)
+        submission = create(:submission, :with_all_tags)
         page = SubmissionsIndexPage.new
 
         page.visit

--- a/spec/system/user_views_submission_spec.rb
+++ b/spec/system/user_views_submission_spec.rb
@@ -89,5 +89,18 @@ RSpec.describe "user views submission" do
         end
       end
     end
+
+    it "can see the submission's tags" do
+      body = "\\(f(x)=x^2\\)\n$$g(x)=x^3$$\n\\[h(x)=x^4\\]"
+      submission = create(:submission, :text, :with_all_tags, body: body) 
+
+      page = ViewSubmissionPage.new
+
+      page.visit(submission, as: user)
+
+      submission.tags.each do |tag|
+        expect(page).to have_tag(tag)
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/mvKg5bLf

this commit allows users to select up to 5 tags
  for their submissions.

other rules:

- minimum of 1 tag must be selected

- minimum of 1 non-media (i.e. filetype) tag must be
  selected

- non-admin / mods are restricted from accessing mod tags

A follow up PR will make the tag links clickable, which
  will take the user to the submission index view, but only
  showing submissions with the clicked-on tag.