### PR TITLE
limit rate of which users can make submissions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,17 @@ class User < ApplicationRecord
       where("lower(username) = ?", username.downcase).first if username.present?
     end
   end
+
+  def update_last_submission_at!
+    update!(last_submission_at: Time.zone.now)
+  end
+
+  def minutes_until_next_submission
+    if last_submission_at.nil?
+      0.0
+    else
+      last_submitted = last_submission_at.in_time_zone(Time.zone)
+      [(10.minutes.since(last_submitted) - Time.zone.now) / 1.minute, 0.0].max.round
+    end
+  end
 end

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -20,3 +20,4 @@ en:
           scheme (http / https) and that the website is up and accepting connections. If the problem
           persists please contact our mod team.
         url_or_body: You must specify an URL or body, but not both. If you submit an URL, put your description in the comments.
+        rate_limit: "You must wait a bit in between submissions. Please try again in %{try_again_min} minutes."

--- a/db/migrate/20200516200636_add_last_submission_at_to_users.rb
+++ b/db/migrate/20200516200636_add_last_submission_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSubmissionAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :last_submission_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_184144) do
+ActiveRecord::Schema.define(version: 2020_05_16_200636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_05_16_184144) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "role", default: 0, null: false
     t.string "username", limit: 20, null: false
+    t.datetime "last_submission_at"
     t.index "lower((email)::text)", name: "index_users_on_LOWER_email", unique: true
     t.index "lower((username)::text)", name: "index_users_on_LOWER_username", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,47 @@
 RSpec.describe User do
   it { should define_enum_for(:role).with_values(member: 0, moderator: 10, admin: 20) }
   it { should have_many(:submissions) }
+
+  describe "#update_last_submission_at!" do
+    it "updates the last submission time to the current time" do
+      now = Time.zone.now
+      travel_to now do
+        user = create(:user)
+
+        expect(user.last_submission_at).to be_nil
+
+        user.update_last_submission_at!
+
+        # this is a hack sort of because the database column doesn't
+        # care about microseconds
+        expect(user.last_submission_at).to eq(now.change(usec: 0))
+      end
+    end
+  end
+
+  describe "#minutes_until_next_submission" do
+    it "is 0.0 if `last_submission_at` is `nil`" do
+      user = build(:user, last_submission_at: nil)
+
+      expect(user.minutes_until_next_submission).to eq(0.0)
+    end
+
+    it "is 0.0 if the current time exceeds 10 minutes since the last submission" do
+      now = Time.zone.now
+      user = build(:user, last_submission_at: now - 20.minutes)
+      travel_to now do
+        expect(user.minutes_until_next_submission).to eq(0.0)
+      end
+    end
+
+    it "10min since last submission MINUS current time in min when current time is within 10min of last submission" do
+      now = Time.zone.now.change(usec: 0)
+      user = build(:user, last_submission_at: now)
+      travel_to now + 7.minutes do
+        # it's been 7 minutes since the last submission, so they
+        # can submit again in 3 minutes
+        expect(user.minutes_until_next_submission).to eq(3.0)
+      end
+    end
+  end
 end

--- a/spec/support/page_objects/create_submission_page.rb
+++ b/spec/support/page_objects/create_submission_page.rb
@@ -66,6 +66,10 @@ class CreateSubmissionPage < PageBase
     has_error?(t("submissions.new.error.url_exists"))
   end
 
+  def has_rate_limit_error?(try_again_min)
+    has_error?(t("submissions.new.error.rate_limit", try_again_min: try_again_min))
+  end
+
   def has_error?(error)
     within find(".errors") do
       has_css?("li.error", text: error)


### PR DESCRIPTION
https://trello.com/c/G5Kr4B5E

this commit adds logic to prevent users from making
  submissions if their last submission was within 10
  minutes of the current time.

the idea is to help prevent users from spamming submissions,
  which will help a great deal in moderating the site.

we can tweak the allowed time between submissions as necessary.