### PR TITLE
adds the ability for users to hide / save submissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ Naming/MethodParameterName:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
+Rails/InverseOf:
+  Enabled: false
+
 Rails/NotNullColumn:
   Enabled: false
 

--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -2,6 +2,24 @@
   @include padding($spacing-smaller null null null);
 }
 
+.submission-hidden .submission-line2 .submission-info {
+  .hide {
+    font-style: italic;
+  }
+  .hide::after {
+    font-style: normal;
+  }
+}
+
+.submission-saved .submission-line2 .submission-info {
+  .save {
+    color: green;
+  }
+  .save::after {
+    color: $scorpion;
+  }
+}
+
 .submission {
   @include padding(null null $spacing-small null);
   .submission-info,

--- a/app/controllers/users/submission_actions_controller.rb
+++ b/app/controllers/users/submission_actions_controller.rb
@@ -1,0 +1,58 @@
+module Users
+  class SubmissionActionsController < ApplicationController
+    def update
+      if current_user.present?
+        handle_request
+      else
+        head :forbidden
+      end
+    end
+
+    private
+
+    def handle_request
+      action = current_user.submission_actions.find_or_initialize_by(submission_action_params)
+      if action.persisted?
+        action.destroy!
+        text = t("submissions.submission_list_item.actions.default.#{action.kind}")
+      else
+        action.save!
+        text = t("submissions.submission_list_item.actions.created.#{action.kind}")
+      end
+
+      render json: {
+        status: status_for_action(action),
+        text: text
+      }
+    end
+
+    def submission_action_params
+      params.require(:submission_action).permit(:submission_short_id, :kind)
+    end
+
+    def status_for_action(action)
+      case action.kind.to_sym
+      when :hidden
+        hidden_action_status(action)
+      when :saved
+        saved_action_status(action)
+      end
+    end
+
+    def hidden_action_status(action)
+      if action.destroyed?
+        :unhidden
+      else
+        :hidden
+      end
+    end
+
+    def saved_action_status(action)
+      if action.destroyed?
+        :unsaved
+      else
+        :saved
+      end
+    end
+  end
+end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SubmissionsHelper
   def submission_href_for(submission)
     submission.url.presence || submission_path(submission.short_id)
@@ -18,6 +20,42 @@ module SubmissionsHelper
   def tag_select_options(user)
     Tag.for_user(user).order(:id).all.map do |tag|
       [tag.id, tag.id]
+    end
+  end
+
+  def submission_classes_for(submission)
+    [saved_class_for(submission), hidden_class_for(submission)].join(" ")
+  end
+
+  def saved_class_for(submission)
+    if submission.saved_action_id.present?
+      "submission-saved"
+    else
+      ""
+    end
+  end
+
+  def hidden_class_for(submission)
+    if submission.hidden_action_id.present?
+      "submission-hidden"
+    else
+      ""
+    end
+  end
+
+  def save_link_text_for(submission)
+    if submission.saved_action_id.present?
+      t("submissions.submission_list_item.actions.created.saved")
+    else
+      t("submissions.submission_list_item.actions.default.saved")
+    end
+  end
+
+  def hide_link_text_for(submission)
+    if submission.hidden_action_id.present?
+      t("submissions.submission_list_item.actions.created.hidden")
+    else
+      t("submissions.submission_list_item.actions.default.hidden")
     end
   end
 end

--- a/app/javascript/packs/submission_actions.js
+++ b/app/javascript/packs/submission_actions.js
@@ -1,0 +1,73 @@
+function updateHideOpacity(element, json) {
+  if (json.status === "hidden") {
+    element.style.opacity = "0.5";
+  } else {
+    element.style.opacity = "initial";
+  }
+}
+
+function updateSubmissionElement(element, json, expectedStatus) {
+  submissionClass = "submission-" + expectedStatus;
+  if (json.status === expectedStatus) {
+    element.classList.add(submissionClass);
+  } else {
+    element.classList.remove(submissionClass);
+  }
+}
+
+function handleUpdate(element, a, json) {
+  if (a.classList.contains("hide")) {
+    updateSubmissionElement(element, json, "hidden");
+    updateHideOpacity(element, json);
+  } else {
+    updateSubmissionElement(element, json, "saved");
+  }
+  a.text = json.text;
+}
+
+function handleResponse(element, a, response) {
+  if (response.status == 200) {
+    response.json().then(json => handleUpdate(element, a, json));
+  }
+}
+
+function setOnClick(element, a, kind) {
+  a.addEventListener("click", function(e) {
+    e.preventDefault();
+    fetch("/users/submission_actions", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.getElementsByName("csrf-token")[0].content
+      },
+      body: JSON.stringify({
+        submission_action: {
+          kind: kind,
+          submission_short_id: element.id
+        }
+      })
+    }).then(response => handleResponse(element, a, response));
+  });
+}
+
+function setupActionLinks(element) {
+  setOnClick(element, element.getElementsByClassName("hide")[0], "hidden");
+  setOnClick(element, element.getElementsByClassName("save")[0], "saved");
+}
+
+const callback = function() {
+  const elements = document.getElementsByClassName("submission");
+
+  for (let i = 0; i < elements.length; i++) {
+    setupActionLinks(elements[i]);
+  }
+};
+
+if (
+    document.readyState === "complete" ||
+    (document.readyState !== "loading" && !document.documentElement.doScroll)
+) {
+  callback();
+} else {
+  document.addEventListener("DOMContentLoaded", callback);
+}

--- a/app/models/concerns/short_id.rb
+++ b/app/models/concerns/short_id.rb
@@ -13,7 +13,7 @@ module ShortId
     short_id = nil
 
     loop do
-      short_id = SecureRandom.urlsafe_base64(6).gsub(/-|_/, ("a".."z").to_a[rand(26)])
+      short_id = "#{self.class.short_id_prefix}#{SecureRandom.base36(8)}"
       break unless self.class.name.constantize.where(short_id: short_id).exists?
     end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,4 +5,34 @@ class Submission < ApplicationRecord
   belongs_to :domain, optional: true
   has_many :submission_tags
   has_many :tags, through: :submission_tags
+
+  def self.short_id_prefix
+    :s_
+  end
+
+  def self.left_join_saved_info_for(user)
+    joins(left_join_submission_actions_sql(user, :saved))
+  end
+
+  def self.left_join_hidden_info_for(user)
+    joins(left_join_submission_actions_sql(user, :hidden))
+  end
+
+  class << self
+    private
+
+    def left_join_submission_actions_sql(user, kind)
+      tmp_table = "#{kind}_actions"
+      %(
+      LEFT JOIN
+        submission_actions #{tmp_table}
+      ON
+        #{tmp_table}.user_id = #{user.id}
+      AND
+        #{tmp_table}.kind = #{SubmissionAction.kinds[kind]}
+      AND
+        #{tmp_table}.submission_short_id = submissions.short_id
+      ).squish
+    end
+  end
 end

--- a/app/models/submission_action.rb
+++ b/app/models/submission_action.rb
@@ -1,0 +1,9 @@
+class SubmissionAction < ApplicationRecord
+  enum kind: {
+    hidden: 0,
+    saved: 1
+  }
+
+  belongs_to :submission, foreign_key: :submission_short_id, primary_key: :short_id
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   }
 
   has_many :submissions
+  has_many :submission_actions
 
   validates :username, presence: true
 

--- a/app/search_objects/results_paginator.rb
+++ b/app/search_objects/results_paginator.rb
@@ -6,6 +6,7 @@ class ResultsPaginator
     @page = [params.fetch(:page).to_i, MAX_PER_PAGE].min
     @per_page = params.fetch(:per_page)
     @order = params.fetch(:order, { id: :asc })
+    @count_field = params.fetch(:count_field, :id)
   end
 
   def results_page
@@ -16,7 +17,7 @@ class ResultsPaginator
   end
 
   def max_page
-    (scope.count.to_f / per_page).ceil - 1
+    (scope.count(count_field).to_f / per_page).ceil - 1
   end
 
   def offset
@@ -27,7 +28,7 @@ class ResultsPaginator
     end
   end
 
-  attr_reader :page, :per_page, :order
+  attr_reader :page, :per_page, :order, :count_field
 
   private
 

--- a/app/search_objects/submission_search.rb
+++ b/app/search_objects/submission_search.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 class SubmissionSearch
   DEFAULT_PAGE = 0
   DEFAULT_PER_PAGE = 25
 
-  def initialize(params)
+  def initialize(params, user)
     @params = params
+    @user = user
   end
 
   def results_paginator
@@ -12,10 +15,26 @@ class SubmissionSearch
 
   private
 
-  attr_reader :params
+  attr_reader :params, :user
 
   def scope
-    Submission.preload(:user, :domain)
+    Submission.preload(:user, :domain, :tags).then do |rel|
+      if user.present?
+        # hidden submissions aren't going to show up on the index so we don't have
+        # to select the action id here
+        rel.left_join_saved_info_for(user).where(hidden_submissions.arel.exists.not).
+          select("submissions.*, NULL AS hidden_action_id, saved_actions.id AS saved_action_id")
+      else
+        rel.select("submissions.*, NULL AS hidden_action_id, NULL AS saved_action_id")
+      end
+    end
+  end
+
+  def hidden_submissions
+    user.
+      submission_actions.hidden.
+      where("submission_actions.submission_short_id = submissions.short_id").
+      select(1)
   end
 
   def pagination_params

--- a/app/views/submissions/_submission_list_item.html.haml
+++ b/app/views/submissions/_submission_list_item.html.haml
@@ -1,4 +1,4 @@
-.submission{ id: "submission_#{submission.id}" }
+.submission{ id: submission.short_id, class: submission_classes_for(submission) }
   .submission-line1
     %span.submission-link= link_to(submission.title, submission_href_for(submission))
     %span.submission-tags
@@ -15,7 +15,7 @@
       %span.submission-time
         = submitted_time_text(submission)
     %span.submission-info
-      = link_to t(".hide"), "#"
-      = link_to t(".save"), "#"
+      = link_to hide_link_text_for(submission), "", class: "hide"
+      = link_to save_link_text_for(submission), "", class: "save"
     %span.submission-comments
       = link_to t(".comments", count: 25), "#"

--- a/app/views/submissions/index.html.haml
+++ b/app/views/submissions/index.html.haml
@@ -1,2 +1,3 @@
 = render "submission_list", submissions: @paginator.results_page
 = render "shared/pagination_controls", paginator: @paginator
+= javascript_pack_tag "submission_actions"

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -3,3 +3,4 @@
   = sanitize CommonMarker.render_html(@submission.body.gsub("\\", "\\\\\\")) if @submission.body.present?
 
 = javascript_pack_tag :latex
+= javascript_pack_tag "submission_actions"

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -4,8 +4,13 @@ en:
       submitted_by: via 
       authored_by: authored by
       ago: ago
-      hide: hide
-      save: save
+      actions:
+        created:
+          hidden: hidden
+          saved: saved
+        default:
+          hidden: hide
+          saved: save
       comments: "%{count} comments"
     new:
       title: Make a new submission

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
 
   resources :submissions, only: [:index, :new, :create]
   resources :submissions, only: [:show], param: :short_id, path: :s
+
+  namespace :users do
+    resource :submission_actions, only: [:update]
+  end
 end

--- a/db/migrate/20200516221059_create_submission_actions.rb
+++ b/db/migrate/20200516221059_create_submission_actions.rb
@@ -1,0 +1,18 @@
+class CreateSubmissionActions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submission_actions do |t|
+      t.belongs_to :user, null: false, index: false, foreign_key: { on_delete: :cascade }
+      t.string :submission_short_id, null: false
+      t.integer :kind, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :submission_actions, :submissions,
+      column: :submission_short_id, primary_key: :short_id
+    add_index :submission_actions, [:user_id, :kind, :submission_short_id], unique: true,
+      name: "idx_unique_submission_actions"
+    add_index :submission_actions, :submission_short_id
+    add_index :submission_actions, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_200636) do
+ActiveRecord::Schema.define(version: 2020_05_16_221059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,17 @@ ActiveRecord::Schema.define(version: 2020_05_16_200636) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["banned_by_id"], name: "index_domains_on_banned_by_id", where: "(banned_by_id IS NOT NULL)"
     t.index ["name"], name: "index_domains_on_name", unique: true
+  end
+
+  create_table "submission_actions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "submission_short_id", null: false
+    t.integer "kind", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["kind"], name: "index_submission_actions_on_kind"
+    t.index ["submission_short_id"], name: "index_submission_actions_on_submission_short_id"
+    t.index ["user_id", "kind", "submission_short_id"], name: "idx_unique_submission_actions", unique: true
   end
 
   create_table "submission_tags", force: :cascade do |t|
@@ -85,6 +96,8 @@ ActiveRecord::Schema.define(version: 2020_05_16_200636) do
   end
 
   add_foreign_key "domains", "users", column: "banned_by_id"
+  add_foreign_key "submission_actions", "submissions", column: "submission_short_id", primary_key: "short_id"
+  add_foreign_key "submission_actions", "users", on_delete: :cascade
   add_foreign_key "submission_tags", "submissions", on_delete: :cascade
   add_foreign_key "submission_tags", "tags", on_delete: :cascade
   add_foreign_key "submissions", "domains"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.admin.
+  create(username: "admin", email: "admin@example.com", password: "abcd1234", password_confirmation: "abcd1234").
+  confirm
+User.moderator.
+  create(username: "moderator", email: "mod@example.com", password: "abcd1234", password_confirmation: "abcd1234").
+  confirm
+User.member.
+  create(username: "member", email: "member@example.com", password: "abcd1234", password_confirmation: "abcd1234").
+  confirm

--- a/spec/factories/submission_actions.rb
+++ b/spec/factories/submission_actions.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :submission_action do
+    submission
+    user
+
+    trait :hidden do
+      kind { :hidden }
+    end
+
+    trait :saved do
+      kind { :saved }
+    end
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
   trait :with_all_tags do
     after(:build) do |submission|
-      Tag.kinds.keys.each do |kind|
+      Tag.kinds.each_key do |kind|
         submission.tags << build(:"#{kind}_tag")
       end
     end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,5 +1,4 @@
-module SubmissionsHelper
-  include ActiveSupport::Testing::TimeHelpers
+RSpec.describe SubmissionsHelper do
   describe "#submission_href_for" do
     context "when the submission has a URL" do
       it "is the URL" do
@@ -49,6 +48,88 @@ module SubmissionsHelper
           "#{t('datetime.distance_in_words.about_x_hours.one')} "\
           "#{t('submissions.submission_list_item.ago')}"
         )
+      end
+    end
+  end
+
+  describe "#saved_class_for" do
+    context "when `saved_action_id` is defined on the submission" do
+      it "returns `submission-saved` when the id is present" do
+        create(:submission, :text)
+        submission = Submission.select("*, 666 AS saved_action_id").first
+
+        expect(helper.saved_class_for(submission)).to eq("submission-saved")
+      end
+
+      it "returns the empty string when the id is nil" do
+        create(:submission, :text)
+        submission = Submission.select("*, NULL AS saved_action_id").first
+
+        expect(helper.saved_class_for(submission)).to eq("")
+      end
+    end
+
+    context "when `saved_action_id` is not defined on the submission" do
+      it "raises an error" do
+        submission = build(:submission, :text)
+
+        expect { helper.saved_class_for(submission) }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "#save_link_text_for" do
+    context "when `saved_action_id` is defined on the submission" do
+      it "returns `submission-saved` when the id is present" do
+        create(:submission, :text)
+        submission = Submission.select("*, 666 AS saved_action_id").first
+
+        expect(helper.save_link_text_for(submission)).
+          to eq(t("submissions.submission_list_item.actions.created.saved"))
+      end
+
+      it "returns the empty string when the id is nil" do
+        create(:submission, :text)
+        submission = Submission.select("*, NULL AS saved_action_id").first
+
+        expect(helper.save_link_text_for(submission)).
+          to eq(t("submissions.submission_list_item.actions.default.saved"))
+      end
+    end
+
+    context "when `saved_action_id` is not defined on the submission" do
+      it "raises an error" do
+        submission = build(:submission, :text)
+
+        expect { helper.saved_link_text_for(submission) }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "#hide_link_text_for" do
+    context "when `saved_action_id` is defined on the submission" do
+      it "returns `submission-saved` when the id is present" do
+        create(:submission, :text)
+        submission = Submission.select("*, 666 AS hidden_action_id").first
+
+        expect(helper.hide_link_text_for(submission)).
+          to eq(t("submissions.submission_list_item.actions.created.hidden"))
+      end
+
+      it "returns the empty string when the id is nil" do
+        create(:submission, :text)
+        submission = Submission.select("*, NULL AS hidden_action_id").first
+
+        expect(helper.hide_link_text_for(submission)).
+          to eq(t("submissions.submission_list_item.actions.default.hidden"))
+      end
+    end
+
+    context "when `saved_action_id` is not defined on the submission" do
+      it "raises an error" do
+        submission = build(:submission, :text)
+
+        expect { helper.hide_link_text_for(submission) }.to raise_error(NoMethodError)
       end
     end
   end

--- a/spec/models/submission_action_spec.rb
+++ b/spec/models/submission_action_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe SubmissionAction, type: :model do
+  it do
+    should belong_to(:submission).
+      with_foreign_key(:submission_short_id).
+      with_primary_key(:short_id)
+  end
+
+  it { should belong_to(:user) }
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe Submission, type: :model do
   it { should have_many(:submission_tags) }
   it { should have_many(:tags).through(:submission_tags) }
 
+  describe ".short_id_prefix" do
+    it "is :s_" do
+      expect(Submission.short_id_prefix).to eq(:s_)
+    end
+  end
+
   describe "#before_create" do
-    it "sets its short id" do
+    it "sets its short id to a random 8-character base-36 string prefixed with s_" do
       submission = build(:submission, :url)
 
       expect(submission.short_id).to be_nil
@@ -13,7 +19,8 @@ RSpec.describe Submission, type: :model do
       submission.save!
 
       expect(submission.short_id).not_to be_nil
-      expect(submission.short_id.length).to eq(8)
+      expect(submission.short_id).to start_with("s_")
+      expect(submission.short_id[2..-1].length).to eq(8)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe User do
   it { should define_enum_for(:role).with_values(member: 0, moderator: 10, admin: 20) }
   it { should have_many(:submissions) }
+  it { should have_many(:submission_actions) }
 
   describe "#update_last_submission_at!" do
     it "updates the last submission time to the current time" do

--- a/spec/requests/users/submission_actions_spec.rb
+++ b/spec/requests/users/submission_actions_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe "submission actions" do
+  describe "PUT /users/submission_actions" do
+    let(:user) { create(:user) }
+    let(:submission) { create(:submission, :text) }
+
+    context "when the user is logged in" do
+      before { login_as(user) }
+
+      context "when the action already exists" do
+        # this is equivalent to clicking unsave / unhide
+        it "destroys it" do
+          create(:submission_action, :hidden, user: user, submission: submission)
+          put "/users/submission_actions",
+            params: {
+              submission_action: {
+                submission_short_id: submission.short_id, kind: :hidden
+              }
+            }
+
+          expect(response).to be_ok
+          expect(SubmissionAction.hidden.count).to eq(0)
+
+          body = JSON.parse(response.body)
+
+          expect(body).to eq({
+            "status" => "unhidden",
+            "text" => I18n.t("submissions.submission_list_item.actions.default.hidden")
+          })
+        end
+      end
+
+      context "when the action does not exist" do
+        it "creates it" do
+          put "/users/submission_actions",
+            params: {
+              submission_action: {
+                submission_short_id: submission.short_id, kind: :hidden
+              }
+            }
+
+          expect(response).to be_ok
+          expect(SubmissionAction.hidden.count).to eq(1)
+          expect(SubmissionAction.where(user: user, submission: submission)).to exist
+
+          body = JSON.parse(response.body)
+
+          expect(body).to eq({
+            "status" => "hidden",
+            "text" => I18n.t("submissions.submission_list_item.actions.created.hidden")
+          })
+        end
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "returns a 403 status code" do
+        put "/users/submission_actions",
+          params: {
+            submission_action: {
+              submission_short_id: submission.short_id, kind: :hidden
+            }
+          }
+
+        expect(response).to be_forbidden
+        expect(SubmissionAction.hidden.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/search_objects/results_paginator_spec.rb
+++ b/spec/search_objects/results_paginator_spec.rb
@@ -3,16 +3,16 @@ RSpec.describe ResultsPaginator do
     it "properly offsets and limits the results" do
       s1, s2, s3 = create_list(:submission, 3)
 
-      expect(ResultsPaginator.new(Submission.all, page: 0, per_page: 3).results_page).to eq(
+      expect(ResultsPaginator.new(Submission.all, { page: 0, per_page: 3 }).results_page).to eq(
         [s1, s2, s3]
       )
-      expect(ResultsPaginator.new(Submission.all, page: 0, per_page: 1).results_page).to eq(
+      expect(ResultsPaginator.new(Submission.all, { page: 0, per_page: 1 }).results_page).to eq(
         [s1]
       )
-      expect(ResultsPaginator.new(Submission.all, page: 1, per_page: 1).results_page).to eq(
+      expect(ResultsPaginator.new(Submission.all, { page: 1, per_page: 1 }).results_page).to eq(
         [s2]
       )
-      expect(ResultsPaginator.new(Submission.all, page: 2, per_page: 1).results_page).to eq(
+      expect(ResultsPaginator.new(Submission.all, { page: 2, per_page: 1 }).results_page).to eq(
         [s3]
       )
     end
@@ -22,7 +22,7 @@ RSpec.describe ResultsPaginator do
     it "is a function of the result count and `per_page`" do
       create_list(:submission, 3)
 
-      results = ResultsPaginator.new(Submission.all, page: 0, per_page: 1)
+      results = ResultsPaginator.new(Submission.all, { page: 0, per_page: 1 })
 
       # three pages, started from 0
       expect(results.max_page).to be(2)
@@ -32,7 +32,7 @@ RSpec.describe ResultsPaginator do
   describe "#offset" do
     context "when we're on the first page" do
       it "is 0" do
-        results = ResultsPaginator.new(Submission.all, page: 0, per_page: 25)
+        results = ResultsPaginator.new(Submission.all, { page: 0, per_page: 25 })
 
         expect(results.offset).to be(0)
       end
@@ -40,7 +40,7 @@ RSpec.describe ResultsPaginator do
 
     context "when we're on literally any other page" do
       it "is the page number multipled by `per_page`" do
-        results = ResultsPaginator.new(Submission.all, page: 2, per_page: 69)
+        results = ResultsPaginator.new(Submission.all, { page: 2, per_page: 69 })
 
         expect(results.offset).to be(138)
       end

--- a/spec/search_objects/submission_search_spec.rb
+++ b/spec/search_objects/submission_search_spec.rb
@@ -1,9 +1,23 @@
 RSpec.describe SubmissionSearch do
-  describe "#results_pagination" do
+  let(:user) { create(:user) }
+
+  describe "#results_paginator" do
     it "is a `ResultsPaginator`" do
-      search = SubmissionSearch.new({})
+      search = SubmissionSearch.new({}, user)
 
       expect(search.results_paginator).to be_a(ResultsPaginator)
+    end
+  end
+
+  describe "search results" do
+    it "does not include submissions hidden by user" do
+      present1, present2, hidden = create_list(:submission, 3, :text)
+      create(:submission_action, :hidden, user: user, submission: hidden)
+
+      search = SubmissionSearch.new({}, user)
+      results = search.results_paginator.results_page
+
+      expect(results).to match_array([present1, present2])
     end
   end
 end

--- a/spec/support/page_objects/shared_components/submission_actions_component.rb
+++ b/spec/support/page_objects/shared_components/submission_actions_component.rb
@@ -1,0 +1,47 @@
+module SubmissionActionsComponent
+  def save_submission(submission)
+    within find(:css, "##{submission.short_id}") do
+      click_link t("submissions.submission_list_item.actions.default.saved")
+    end
+  end
+
+  def hide_submission(submission)
+    within find(:css, "##{submission.short_id}") do
+      click_link t("submissions.submission_list_item.actions.default.hidden")
+    end
+  end
+
+  def has_hidden_submission?(submission)
+    has_css?("##{submission.short_id}.submission-hidden") &&
+      has_hidden_submission_link?(submission)
+  end
+
+  def has_hidden_submission_link?(submission)
+    has_submission_action_link?(submission, :hidden)
+  end
+
+  def has_saved_submission?(submission)
+    has_css?("##{submission.short_id}.submission-saved") &&
+      has_submission_action_link?(submission, :saved)
+  end
+
+  def has_save_submission_link?(submission)
+    within find(:css, "##{submission.short_id}") do
+      has_css?("a", text: t("submissions.submission_list_item.actions.default.saved"))
+    end
+  end
+
+  def has_hide_submission_link?(submission)
+    within find(:css, "##{submission.short_id}") do
+      has_css?("a", text: t("submissions.submission_list_item.actions.default.hidden"))
+    end
+  end
+
+  private
+
+  def has_submission_action_link?(submission, kind)
+    within find(:css, "##{submission.short_id}") do
+      has_link? t("submissions.submission_list_item.actions.created.#{kind}")
+    end
+  end
+end

--- a/spec/support/page_objects/submissions_index_page.rb
+++ b/spec/support/page_objects/submissions_index_page.rb
@@ -1,8 +1,10 @@
 require "support/page_objects/page_base"
 require "support/page_objects/shared_components/pagination_component"
+require "support/page_objects/shared_components/submission_actions_component"
 
 class SubmissionsIndexPage < PageBase
   include PaginationComponent
+  include SubmissionActionsComponent
 
   def visit(as: nil)
     login_as(as) if as.present?
@@ -11,12 +13,12 @@ class SubmissionsIndexPage < PageBase
   end
 
   def has_submission_row_for?(submission)
-    has_css?("#submission_#{submission.id}") &&
+    has_css?("##{submission.short_id}") &&
       has_correct_submission_info?(submission)
   end
 
   def has_correct_submission_info?(submission)
-    within find("#submission_#{submission.id}") do
+    within find("##{submission.short_id}") do
       has_proper_submission_link?(submission) &&
         has_css?(".submission-user", text: submission.user.username) &&
         has_submission_tags?(submission)

--- a/spec/support/page_objects/view_submission_page.rb
+++ b/spec/support/page_objects/view_submission_page.rb
@@ -1,6 +1,9 @@
 require "support/page_objects/page_base"
+require "support/page_objects/shared_components/submission_actions_component"
 
 class ViewSubmissionPage < PageBase
+  include SubmissionActionsComponent
+
   def visit(submission, as:)
     login_as(as) if as.present?
     super(submission_path(submission.id))

--- a/spec/system/submissions_index_spec.rb
+++ b/spec/system/submissions_index_spec.rb
@@ -77,4 +77,148 @@ RSpec.describe "submissions index" do
       end
     end
   end
+
+  context "when a submission was hidden by a user" do
+    context "when that user is on the index page" do
+      it "does not display that submission" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        visible_submission = create(:submission, :text)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit(as: user)
+
+        expect(page).to have_submission_row_for(visible_submission)
+        expect(page).not_to have_submission_row_for(hidden_submission)
+      end
+    end
+
+    # i.e. we only hide submissions for the user that has
+    # hidden it. This should be obvious but it's worth
+    # having a test for.
+    context "when another user is on the index page" do
+      it "displays the submission" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        user2 = create(:user)
+        visible_submission = create(:submission, :text)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit(as: user2)
+
+        expect(page).to have_submission_row_for(visible_submission)
+        expect(page).to have_submission_row_for(hidden_submission)
+      end
+    end
+
+    context "when a signed out user is on the index page" do
+      it "displays the submission" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        visible_submission = create(:submission, :text)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit
+
+        expect(page).to have_submission_row_for(visible_submission)
+        expect(page).to have_submission_row_for(hidden_submission)
+      end
+    end
+  end
+
+  context "when a submission was saved by a user" do
+    context "when that user is on the index page" do
+      it "indicates that the submission is saved" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit(as: user)
+
+        expect(page).to have_submission_row_for(saved_submission)
+        expect(page).to have_saved_submission(saved_submission)
+      end
+    end
+
+    # similar to above, the submission should only show as "saved"
+    # to the user that saved it.
+    context "when another user is on the index page" do
+      it "does not indicate that the submission is saved" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        user2 = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit(as: user2)
+
+        expect(page).to have_submission_row_for(saved_submission)
+        expect(page).not_to have_saved_submission(saved_submission)
+      end
+    end
+
+    context "when a signed out user is on the index page" do
+      it "does not indicate that the submission is saved" do
+        page = SubmissionsIndexPage.new
+        user = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit
+
+        expect(page).to have_submission_row_for(saved_submission)
+        expect(page).not_to have_saved_submission(saved_submission)
+      end
+    end
+  end
+
+  context "when a user clicks the submission action links", js: true do
+    context "when the user is logged in" do
+      let(:user) { create(:user) }
+
+      it "can add a submission to the user's saved submissions" do
+        submission = create(:submission, :with_all_tags)
+        page = SubmissionsIndexPage.new
+
+        page.visit(as: user)
+
+        page.hide_submission(submission)
+
+        expect(page).to have_hidden_submission(submission)
+        expect(SubmissionAction.hidden.where(user: user, submission: submission)).to exist
+      end
+
+      it "can add a submission to the user's hidden submissions" do
+        submission = create(:submission, :with_all_tags)
+        page = SubmissionsIndexPage.new
+
+        page.visit(as: user)
+
+        page.save_submission(submission)
+
+        expect(page).to have_saved_submission(submission)
+        expect(SubmissionAction.saved.where(user: user, submission: submission)).to exist
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "does not do anything" do
+        submission = create(:submission, :with_all_tags)
+        page = SubmissionsIndexPage.new
+
+        page.visit(as: nil)
+
+        page.save_submission(submission)
+        page.hide_submission(submission)
+
+        expect(page).to have_save_submission_link(submission)
+        expect(page).to have_hide_submission_link(submission)
+        expect(SubmissionAction.count).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/system/user_views_submission_spec.rb
+++ b/spec/system/user_views_submission_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "user views submission" do
 
     it "can see the submission's tags" do
       body = "\\(f(x)=x^2\\)\n$$g(x)=x^3$$\n\\[h(x)=x^4\\]"
-      submission = create(:submission, :text, :with_all_tags, body: body) 
+      submission = create(:submission, :text, :with_all_tags, body: body)
 
       page = ViewSubmissionPage.new
 
@@ -100,6 +100,138 @@ RSpec.describe "user views submission" do
 
       submission.tags.each do |tag|
         expect(page).to have_tag(tag)
+      end
+    end
+  end
+
+  # if for whatever reason a user decides to view a submission that
+  # they have hidden, we should display the proper action link
+  context "when a submission was hidden by a user" do
+    context "when that user is on the submission page" do
+      it "indicates that the submission is hidden" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit(hidden_submission, as: user)
+
+        expect(page).to have_hidden_submission_link(hidden_submission)
+      end
+    end
+
+    context "when another user is on the submission page" do
+      it "does not indicate that the submission is hidden" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        user2 = create(:user)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit(hidden_submission, as: user2)
+
+        expect(page).not_to have_hidden_submission_link(hidden_submission)
+      end
+    end
+
+    context "when a signed out user is on the submission page" do
+      it "does not indicate that the submission is hidden" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        hidden_submission = create(:submission, :text)
+        create(:submission_action, :hidden, user: user, submission: hidden_submission)
+
+        page.visit(hidden_submission, as: nil)
+
+        expect(page).not_to have_hidden_submission_link(hidden_submission)
+      end
+    end
+  end
+
+  context "when a submission was saved by a user" do
+    context "when that user is on the submission page" do
+      it "indicates that the submission is saved" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit(saved_submission, as: user)
+
+        expect(page).to have_saved_submission(saved_submission)
+      end
+    end
+
+    context "when another user is on the submission page" do
+      it "does not indicate that the submission is saved" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        user2 = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit(saved_submission, as: user2)
+
+        expect(page).not_to have_saved_submission(saved_submission)
+      end
+    end
+
+    context "when a signed out user is on the submission page" do
+      it "does not indicate that the submission is saved" do
+        page = ViewSubmissionPage.new
+        user = create(:user)
+        saved_submission = create(:submission, :text)
+        create(:submission_action, :saved, user: user, submission: saved_submission)
+
+        page.visit(saved_submission, as: nil)
+
+        expect(page).not_to have_saved_submission(saved_submission)
+      end
+    end
+  end
+
+  context "when a user clicks the submission action links", js: true do
+    context "when the user is logged in" do
+      let(:user) { create(:user) }
+
+      it "can add a submission to the user's saved submissions" do
+        submission = create(:submission, :with_all_tags)
+        page = ViewSubmissionPage.new
+
+        page.visit(submission, as: user)
+
+        page.hide_submission(submission)
+
+        expect(page).to have_hidden_submission(submission)
+        expect(SubmissionAction.hidden.where(user: user, submission: submission)).to exist
+      end
+
+      it "can add a submission to the user's hidden submissions" do
+        submission = create(:submission, :with_all_tags)
+        page = ViewSubmissionPage.new
+
+        page.visit(submission, as: user)
+
+        page.save_submission(submission)
+
+        expect(page).to have_saved_submission(submission)
+        expect(SubmissionAction.saved.where(user: user, submission: submission)).to exist
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "does not do anything" do
+        submission = create(:submission, :with_all_tags)
+        page = ViewSubmissionPage.new
+
+        page.visit(submission, as: nil)
+
+        page.save_submission(submission)
+        page.hide_submission(submission)
+
+        expect(page).to have_save_submission_link(submission)
+        expect(page).to have_hide_submission_link(submission)
+        expect(SubmissionAction.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/iNwsvA8X

this commit introduces "submission actions", which at present
  are just a means of hiding / saving submissions for a user.

when the user hides a submission on the index, we will lower its
  opacity, and on the next page load it will not be included in
  the results at all (vs removing it from the dom immediately).

for hidden / saved submissions, both action links will be changed
  to their active status when an action was created by the user for
  a particular submission, ie:

- "hide" -> "hidden" when a user has hidden a submission

- "save" -> "saved" when a user saved a submission (we also change the
  color of the link text)