### PR TITLE
adds comment model and some supporting functionality

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,12 @@
+class Comment < ApplicationRecord
+  include ShortId
+  include Comments::TreeMethods
+
+  belongs_to :user
+  belongs_to :submission
+  belongs_to :parent, optional: true, class_name: "Comment"
+
+  def self.short_id_prefix
+    :c_
+  end
+end

--- a/app/models/comments/postgresql_tree_adapter.rb
+++ b/app/models/comments/postgresql_tree_adapter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Comments
+  module PostgresqlTreeAdapter
+    extend ActiveSupport::Concern
+
+    included do
+      before_create :set_ancestry_path
+
+      has_many :children, class_name: "Comment", foreign_key: :parent_id
+    end
+
+    def root_node?
+      parent_id.nil?
+    end
+
+    def childless?
+      children.none?
+    end
+
+    # the `@>` operator is asking "is the left an ancestor of the right?"
+    def descendants
+      self.class.where("? @> ancestry_path", ancestor_path)
+    end
+
+    def siblings
+      # if the ancestry path is present, we want to find all nodes
+      # with the same ancestry path. if it's not, then we have a
+      # root node which cannot have siblings.
+      # we exclude `self` from the resulting relation.
+      if ancestry_path.present?
+        self.class.where("? = ancestry_path", ancestry_path).where.not(id: id)
+      else
+        self.class.none
+      end
+    end
+
+    private
+
+    def set_ancestry_path
+      if parent.present?
+        prefix = (parent.ancestry_path.present? ? "#{parent.ancestry_path}." : "")
+        self.ancestry_path = "#{prefix}#{parent.short_id}"
+      end
+    end
+
+    def ancestor_path
+      prefix = ancestry_path.present? ? "#{ancestry_path}." : ""
+      "#{prefix}#{short_id}"
+    end
+  end
+end

--- a/app/models/comments/tree_methods.rb
+++ b/app/models/comments/tree_methods.rb
@@ -1,0 +1,15 @@
+module Comments
+  module TreeMethods
+    extend ActiveSupport::Concern
+
+    included do
+      # TODO: add support for other db adapters
+      case ActiveRecord::Base.connection.adapter_name.downcase
+      when "postgresql"
+        include PostgresqlTreeAdapter
+      else
+        raise "unsupported database adapter"
+      end
+    end
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,6 +5,7 @@ class Submission < ApplicationRecord
   belongs_to :domain, optional: true
   has_many :submission_tags
   has_many :tags, through: :submission_tags
+  has_many :comments
 
   def self.short_id_prefix
     :s_

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
 
   has_many :submissions
   has_many :submission_actions
+  has_many :comments
 
   validates :username, presence: true
 

--- a/db/migrate/20200517210826_create_comments.rb
+++ b/db/migrate/20200517210826_create_comments.rb
@@ -1,0 +1,28 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    adapter = ActiveRecord::Base.connection.adapter_name.downcase
+    enable_extension "ltree" if adapter == "postgresql"
+    create_table :comments do |t|
+      t.string :short_id, null: false
+      t.belongs_to :user, null: false, foreign_key: { on_delete: :cascade }
+      t.belongs_to :submission, null: false, foreign_key: { on_delete: :cascade }
+      # we're keeping the reference to parent to enforce some degree of foreign
+      # key constraints. We don't want to end up with orphaned trees.
+      t.belongs_to :parent, null: true,
+        foreign_key: { to_table: :comments, on_delete: :cascade }
+      t.text :body, null: false
+      if adapter == "postgresql"
+        # use LTREE extension for efficiently managing comment ancestry paths
+        t.ltree :ancestry_path, null: true
+      else
+        # TODO: figure out if useful extensions exist for other dbms
+        t.text :ancestry_path, null: true
+      end
+
+      t.timestamps
+    end
+
+    add_index :comments, :short_id, unique: true
+    add_index :comments, :ancestry_path, using: :gist if adapter == "postgresql"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_221059) do
+ActiveRecord::Schema.define(version: 2020_05_17_210826) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "ltree"
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.string "short_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "submission_id", null: false
+    t.bigint "parent_id"
+    t.text "body", null: false
+    t.ltree "ancestry_path"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ancestry_path"], name: "index_comments_on_ancestry_path", using: :gist
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
+    t.index ["short_id"], name: "index_comments_on_short_id", unique: true
+    t.index ["submission_id"], name: "index_comments_on_submission_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "domains", force: :cascade do |t|
     t.string "name", null: false
@@ -95,6 +112,9 @@ ActiveRecord::Schema.define(version: 2020_05_16_221059) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "comments", "comments", column: "parent_id", on_delete: :cascade
+  add_foreign_key "comments", "submissions", on_delete: :cascade
+  add_foreign_key "comments", "users", on_delete: :cascade
   add_foreign_key "domains", "users", column: "banned_by_id"
   add_foreign_key "submission_actions", "submissions", column: "submission_short_id", primary_key: "short_id"
   add_foreign_key "submission_actions", "users", on_delete: :cascade

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :comment do
+    user
+    parent { nil }
+    submission do
+      if parent.present?
+        parent.submission
+      else
+        build(:submission)
+      end
+    end
+    sequence(:body) { |n| "a great comment body text #{n}" }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:submission) }
+  it { should belong_to(:parent).optional.class_name("Comment") }
+
+  describe ".short_id_prefix" do
+    it "is :c_" do
+      expect(Comment.short_id_prefix).to eq(:c_)
+    end
+  end
+
+  describe "#before_create" do
+    it "sets its short id to a random 8-character base-36 string prefixed with c_" do
+      comment = build(:comment)
+
+      expect(comment.short_id).to be_nil
+
+      comment.save!
+
+      expect(comment.short_id).not_to be_nil
+      expect(comment.short_id).to start_with("c_")
+      expect(comment.short_id[2..-1].length).to eq(8)
+    end
+  end
+
+  describe "#ancestry_path" do
+    it "is a `.` connected path containing each ancestral short id in order" do
+      comment = create(:comment)
+      child = create(:comment, parent: comment)
+      grand_child = create(:comment, parent: child)
+      great_grand_child = create(:comment, parent: grand_child)
+
+      expect(comment.ancestry_path).to be_nil
+      expect(child.ancestry_path).to eq(comment.short_id)
+      expect(grand_child.ancestry_path).
+        to eq("#{comment.short_id}.#{child.short_id}")
+      expect(great_grand_child.ancestry_path).
+        to eq("#{comment.short_id}.#{child.short_id}.#{grand_child.short_id}")
+    end
+  end
+
+  describe "#root_node?" do
+    it "is true if the comment has no parent" do
+      comment = build(:comment, parent: nil)
+
+      expect(comment).to be_root_node
+    end
+
+    it "is false if the comment has a parent" do
+      comment = build(:comment, parent: create(:comment))
+
+      expect(comment).not_to be_root_node
+    end
+  end
+
+  describe "#children" do
+    it "returns a list of all the comment's direct children" do
+      comment = create(:comment)
+      direct_children = create_list(:comment, 3, parent: comment)
+      # these shouldn't get returned since they're not direct children
+      direct_children.each { |c| create(:comment, parent: c) }
+
+      expect(comment.children).to match_array(direct_children)
+    end
+
+    it "is empty if there are no direct children for the comment" do
+      comment = create(:comment)
+
+      expect(comment.children).to be_empty
+    end
+  end
+
+  describe "#childless?" do
+    it "is true if the comment has no children" do
+      comment = create(:comment)
+
+      expect(comment).to be_childless
+    end
+
+    it "is false if the comment has children" do
+      comment = create(:comment)
+      create_list(:comment, 3, parent: comment)
+
+      expect(comment).not_to be_childless
+    end
+  end
+
+  describe "#descendants" do
+    it "returns a list of all the comments descendants (i.e. all children and their children, etc.)" do
+      comment = create(:comment)
+      children = create_list(:comment, 3, parent: comment)
+      grand_children = children.map { |c| create(:comment, parent: c) }
+      great_grand_children = grand_children.map { |c| create(:comment, parent: c) }
+
+      expect(comment.descendants).to match_array(children + grand_children + great_grand_children)
+    end
+
+    it "is empty if there are no descendants for the comment" do
+      comment = create(:comment)
+
+      expect(comment.descendants).to be_empty
+    end
+  end
+
+  describe "#siblings" do
+    it "returns a list of all the comments siblings (i.e. they share a direct parent)" do
+      parent = create(:comment, parent: create(:comment))
+      child1, child2, child3 = create_list(:comment, 3, parent: parent)
+
+      expect(child1.siblings).to match_array([child2, child3])
+    end
+
+    it "is empty if the comment has no siblings" do
+      parent = create(:comment, parent: create(:comment))
+      child = create(:comment, parent: parent)
+
+      expect(child.siblings).to be_empty
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Submission, type: :model do
   it { should belong_to(:domain).optional }
   it { should have_many(:submission_tags) }
   it { should have_many(:tags).through(:submission_tags) }
+  it { should have_many(:comments) }
 
   describe ".short_id_prefix" do
     it "is :s_" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe User do
   it { should define_enum_for(:role).with_values(member: 0, moderator: 10, admin: 20) }
   it { should have_many(:submissions) }
   it { should have_many(:submission_actions) }
+  it { should have_many(:comments) }
 
   describe "#update_last_submission_at!" do
     it "updates the last submission time to the current time" do


### PR DESCRIPTION
https://trello.com/c/Jj1W2US4

This commit introduces a `Comment` model for holding comments
  on submissions.

We also introduce the an extension for postgres called
  [LTREE](https://www.postgresql.org/docs/current/ltree.html).

This extension is used to support the tree structure that arises
  from comments.

Since we're planning to use postgres in production, and my focus
  is not to try to dive into the weeds in MySQL and other DBMs,
  I've deferred adding support for non-postgres DBMs in this commit.
  (Though if anyone feels like it, I've purposefully structured this to
  be extendable).