### PR TITLE
fixes production LaTeX issue

### DIFF
--- a/app/javascript/packs/latex.js
+++ b/app/javascript/packs/latex.js
@@ -1,4 +1,4 @@
-import '../latex_styles';
+import '../latex_styles.sass';
 
 const katex = require('katex');
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,8 @@
     = csp_meta_tag
     = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
     = javascript_pack_tag "application", "data-turbolinks-track": "reload"
+    - if content_for?(:page_styles)
+      = yield :page_styles
   %body
     = render "layouts/navbar"
     - flash.each do |key, value|

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -4,7 +4,8 @@
 .comments-container
   = render "comments/form", comment: @root_comment, parent: nil
   = render "comments/comment_tree", comments_by_parent: @comments_by_parent
-
-= javascript_pack_tag :latex
-= javascript_pack_tag "submission_actions"
-= javascript_pack_tag "comment"
+- content_for :page_styles do
+  = stylesheet_pack_tag "latex", "data-turbolinks-track": "reload"
+  = javascript_pack_tag "latex"
+  = javascript_pack_tag "submission_actions"
+  = javascript_pack_tag "comment"

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION
I _despise_ webpacker. Basically, it was ignoring the imported
  katex styles in production.

Well...actually it was more so that in development it magically
  just worked even though we weren't using the stylesheet pack
  tag to import that styles related to the pack.

I'm too annoyed to try to figure out the reasoning behind this
  behavior at the moment.