### PR TITLE
Various css fixes

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -6,7 +6,7 @@ button,
   background-color: $action-color;
   border: 0;
   border-radius: $border-radius;
-  color: $action-color--contrast;
+  color: $white;
   cursor: pointer;
   display: inline-block;
   font-family: $font-stack;
@@ -39,5 +39,9 @@ button,
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+
+  &:active {
+    background-color: darken($action-color, 10%);
   }
 }

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -19,8 +19,11 @@ label {
 input,
 select,
 textarea {
-  display: block;
   font-size: 1rem;
+}
+
+.checkbox {
+  vertical-align: middle;
 }
 
 [type="color"],
@@ -78,7 +81,7 @@ textarea {
 
 [type="checkbox"],
 [type="radio"] {
-  margin: 0 $spacing-xs 0 $spacing-small;
+  margin: 0 $spacing-xs;
 }
 
 [type="file"] {
@@ -86,9 +89,15 @@ textarea {
   width: 100%;
 }
 
-select {
+#tag-select {
   margin-bottom: $spacing-small;
   width: 100%;
+  border: $border;
+  box-shadow: $box-shadow;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  font-family: $font-stack;
+  font-style: italic;;
 }
 
 [type="checkbox"],

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -26,49 +26,24 @@ $viewport-background-color: $base-background-color;
 $font-stack: 'Computer Modern Serif', "CMU Serif", system-ui, sans-serif;
 $font-stack-mono: "Consolas", "Menlo", monospace;
 
-@font-face {
-  font-family: "Computer Modern Serif";
-  src: font-url("cmunrm.eot") format("embedded-opentype");
-  src: font-url("cmunrm.eot?#iefix") format("embedded-opentype"),
-    font-url("cmunrm.woff") format("woff"),
-    font-url("cmunrm.ttf") format("truetype"),
-    font-url("cmunrm.svg") format("svg");
-  font-style: normal;
-  font-weight: normal;
+@mixin font-import($name, $path, $style, $weight) {
+  @font-face {
+    font-family: $name;
+    src: font-url($path + ".eot") format("embedded-opentype");
+    src: font-url($path + ".eot?#iefix") format("embedded-opentype"),
+      font-url($path + ".woff") format("woff"),
+      font-url($path + ".ttf") format("truetype"),
+      font-url($path + ".svg") format("svg");
+    font-style: $style;
+    font-weight: $weight;
+  }
 }
 
-@font-face {
-  font-family: "computer-modern-serif";
-  src: font-url("cmunbx.eot") format("embedded-opentype");
-  src: font-url("cmunbx.eot?#iefix") format("embedded-opentype"),
-    url("fonts/cmunbx.woff") format("woff"),
-    url("fonts/cmunbx.ttf") format("truetype"),
-    url("fonts/cmunbx.svg") format("svg");
-  font-style: normal;
-  font-weight: bold;
-}
+@include font-import("Computer Modern Serif", "cmunrm", "normal", "normal");
+@include font-import("computer-modern-serif", "cmunbx", "normal", "bold");
+@include font-import("computer-modern-serif", "cmunti", "italic", "normal");
+@include font-import("computer-modern-serif", "cmunbi", "italic", "bold");
 
-@font-face {
-  font-family: "computer-modern-serif";
-  src: font-url("cmunti.eot") format("embedded-opentype");
-  src: font-url("cmunti.eot?#iefix") format("embedded-opentype"),
-    url("fonts/cmunti.woff") format("woff"),
-    url("fonts/cmunti.ttf") format("truetype"),
-    url("fonts/cmunti.svg") format("svg");
-  font-style: italic;
-  font-weight: normal;
-}
-
-@font-face {
-  font-family: "computer-modern-serif";
-  src: font-url("cmunbi.eot") format("embedded-opentype");
-  src: font-url("cmunbi.eot?#iefix") format("embedded-opentype"),
-    url("fonts/cmunbi.woff") format("woff"),
-    url("fonts/cmunbi.ttf") format("truetype"),
-    url("fonts/cmunbi.svg") format("svg");
-  font-style: italic;
-  font-weight: bold;
-}
 $font-weight-thin: thin;
 $font-weight-normal: normal;
 $font-weight-bold: bold;

--- a/app/assets/stylesheets/pages/_submissions.scss
+++ b/app/assets/stylesheets/pages/_submissions.scss
@@ -99,6 +99,7 @@
       justify-self: center;
       align-self: center;
       font-family: $font-stack-mono;
+      white-space: nowrap;
     }
     .upvote, .hide-comment {
       line-height: 0.9;

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for comment, url: submission_comments_path(@submission.short_id) do |f|
   = f.input :body, as: :text, input_html: { rows: 5 }, label: false, required: true
   = f.input :parent_id, as: :hidden, input_html: { value: parent&.id }, wrapper: false
-  = f.submit
+  = f.button :button, type: :submit
   - if parent.present?
     = f.button :button, t(".cancel"), type: :reset, class: "cancel-reply"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta{ :content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
     %title SimpleGroup
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -11,4 +11,4 @@
   .original-author-statement
     = f.input :original_author, as: :boolean, wrapper: :left_hand_label
     = t(".original_author")
-  = f.submit
+  = f.button :button, type: :submit


### PR DESCRIPTION
- Makes checkboxes next to text work more often

- Fixes hide button wrapping on Safari

- Fixes odd button styling on iOS Safari

- Makes buttons a tiny bit prettier

- Styles tag selection

- Working mixin that generates a `@font-face`

- Adds `<meta name="viewport" content="width=device-width, initial-scale=1">` to head to allow mobile version to trigger on mobile