### PR TITLE
simplifies downvoting vision

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -4,33 +4,12 @@ class Vote < ApplicationRecord
   belongs_to :votable, polymorphic: true
   belongs_to :user
   validate :supported_votable_type
-  validates :downvote_reason,
-    absence: { message: I18n.t("votes.errors.downvote_reason_for_upvote") },
-    if: ->(v) { v.upvote? }
-  validates :downvote_reason,
-    presence: { message: I18n.t("votes.errors.missing_downvote_reason") },
-    if: ->(v) { v.downvote? }
-  validate :valid_downvote_reason,
-    if: ->(v) { v.downvote? && v.downvote_reason.present? }
 
   enum kind: {
     upvote: 0,
     downvote: 1
   }
 
-  enum downvote_reason: {
-    off_topic: 0,
-    incorrect: 5,
-    spam: 10,
-    mean: 15,
-    unhelpful: 20,
-    troll: 25,
-    broken_link: 30,
-    repost: 35
-  }
-
-  SUBMISSION_DOWNVOTE_REASONS = %i[off_topic incorrect spam troll broken_link repost].freeze
-  COMMENT_DOWNVOTE_REASONS = %i[off_topic incorrect spam mean unhelpful troll].freeze
   SUPPORTED_VOTABLE_TYPES = [Submission, Comment].freeze
 
   private
@@ -41,27 +20,6 @@ class Vote < ApplicationRecord
         :votable_type,
         I18n.t("votes.errors.unsupported_votable_type", type: votable_type.pluralize.downcase)
       )
-    end
-  end
-
-  def valid_downvote_reason
-    case votable
-    when Submission
-      validate_submission_downvote_reason
-    when Comment
-      validate_comment_downvote_reason
-    end
-  end
-
-  def validate_submission_downvote_reason
-    unless SUBMISSION_DOWNVOTE_REASONS.include?(downvote_reason.to_sym)
-      errors.add(:downvote_reason, I18n.t("votes.errors.invalid_submission_downvote_reason"))
-    end
-  end
-
-  def validate_comment_downvote_reason
-    unless COMMENT_DOWNVOTE_REASONS.include?(downvote_reason.to_sym)
-      errors.add(:downvote_reason, I18n.t("votes.errors.invalid_comment_downvote_reason"))
     end
   end
 end

--- a/db/migrate/20200521044543_create_votes.rb
+++ b/db/migrate/20200521044543_create_votes.rb
@@ -4,7 +4,6 @@ class CreateVotes < ActiveRecord::Migration[6.0]
       t.belongs_to :votable, null: false, index: false, polymorphic: true
       t.belongs_to :user, null: false, index: false, foreign_key: { on_delete: :cascade }
       t.integer :kind, null: false
-      t.integer :downvote_reason
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,7 +117,6 @@ ActiveRecord::Schema.define(version: 2020_05_21_044543) do
     t.bigint "votable_id", null: false
     t.bigint "user_id", null: false
     t.integer "kind", null: false
-    t.integer "downvote_reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "votable_type", "votable_id", "kind"], name: "idx_uniq_votes_user_votable_and_kind", unique: true

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -2,30 +2,20 @@ FactoryBot.define do
   factory :vote do
     user
 
+    trait :submission do
+      association :votable, factory: [:submission, :text]
+    end
+
+    trait :comment do
+      association :votable, factory: :comment
+    end
+
     factory :upvote do
       kind { :upvote }
-
-      trait :submission do
-        association :votable, factory: [:submission, :text]
-      end
-
-      trait :comment do
-        association :votable, factory: :comment
-      end
     end
 
     factory :downvote do
       kind { :downvote }
-
-      trait :submission do
-        association :votable, factory: [:submission, :text]
-        downvote_reason { Vote::SUBMISSION_DOWNVOTE_REASONS.sample }
-      end
-
-      trait :comment do
-        association :votable, factory: :comment
-        downvote_reason { Vote::COMMENT_DOWNVOTE_REASONS.sample }
-      end
     end
   end
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -19,19 +19,6 @@ RSpec.describe Vote, type: :model do
     it { should define_enum_for(:kind).with_values(upvote: 0, downvote: 1) }
   end
 
-  it do
-    should define_enum_for(:downvote_reason).with_values(
-      off_topic: 0,
-      incorrect: 5,
-      spam: 10,
-      mean: 15,
-      unhelpful: 20,
-      troll: 25,
-      broken_link: 30,
-      repost: 35
-    )
-  end
-
   describe "validations" do
     it "validates that the vote is for the proper votable type" do
       vote = build(:upvote, votable: build(:user))
@@ -40,60 +27,6 @@ RSpec.describe Vote, type: :model do
       expect(vote.errors[:votable_type]).to include(
         I18n.t("votes.errors.unsupported_votable_type", type: "users")
       )
-    end
-
-    describe "downvote reason" do
-      context "when the vote is an upvote" do
-        it "does not allow a downvote reason" do
-          submission_upvote = build(:upvote, :submission, downvote_reason: :off_topic)
-
-          expect(submission_upvote).not_to be_valid
-          expect(submission_upvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.downvote_reason_for_upvote")
-          )
-
-          comment_upvote = build(:upvote, :comment, downvote_reason: :off_topic)
-
-          expect(comment_upvote).not_to be_valid
-          expect(comment_upvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.downvote_reason_for_upvote")
-          )
-        end
-      end
-
-      context "when the vote is a downvote" do
-        it "requires a downvote reason" do
-          submission_downvote = build(:downvote, :submission, downvote_reason: nil)
-
-          expect(submission_downvote).not_to be_valid
-          expect(submission_downvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.missing_downvote_reason")
-          )
-
-          comment_downvote = build(:downvote, :comment, downvote_reason: nil)
-
-          expect(comment_downvote).not_to be_valid
-          expect(comment_downvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.missing_downvote_reason")
-          )
-        end
-
-        it "requires the correct downvote reason for the votable type" do
-          submission_downvote = build(:downvote, :submission, downvote_reason: :mean)
-
-          expect(submission_downvote).not_to be_valid
-          expect(submission_downvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.invalid_submission_downvote_reason")
-          )
-
-          comment_downvote = build(:downvote, :comment, downvote_reason: :broken_link)
-
-          expect(comment_downvote).not_to be_valid
-          expect(comment_downvote.errors[:downvote_reason]).to include(
-            I18n.t("votes.errors.invalid_comment_downvote_reason")
-          )
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
see discussion on https://github.com/hernanat/simple_group/pull/30

we've opted to keep downvoting simpler for now and not require
  users to select a predefined reason, which may be seen as limiting.

instead, we'll require that the user has already commented in response
  to what they're downvoting (behavior to come in a subsequent PR).