### PR TITLE
fixes unique index on votes

### DIFF
--- a/db/migrate/20200521044543_create_votes.rb
+++ b/db/migrate/20200521044543_create_votes.rb
@@ -8,8 +8,8 @@ class CreateVotes < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    add_index :votes, [:user_id, :votable_type, :votable_id, :kind], unique: true,
-      name: "idx_uniq_votes_user_votable_and_kind"
+    add_index :votes, [:user_id, :votable_type, :votable_id], unique: true,
+      name: "idx_uniq_votes_user_and_votable"
     add_index :votes, [:votable_type, :votable_id, :kind]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2020_05_21_044543) do
     t.integer "kind", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id", "votable_type", "votable_id", "kind"], name: "idx_uniq_votes_user_votable_and_kind", unique: true
+    t.index ["user_id", "votable_type", "votable_id"], name: "idx_uniq_votes_user_and_votable", unique: true
     t.index ["votable_type", "votable_id", "kind"], name: "index_votes_on_votable_type_and_votable_id_and_kind"
   end
 


### PR DESCRIPTION
I'm a dummy. Previously the unique index included the
  vote `kind` (i.e. `upvote` / `downvote`).

This is not desirable because then a user could conceivably
  have both an upvote and a downvote for a given votable
  entity. We only want to allow one or the other.