### PR TITLE
adds in voting APIs for comments and submissions

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class BaseController < ApplicationController
+      before_action -> { head(:forbidden) unless user_signed_in? }
+    end
+  end
+end

--- a/app/controllers/api/v1/comments/downvotes_controller.rb
+++ b/app/controllers/api/v1/comments/downvotes_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V1
+    module Comments
+      class DownvotesController < BaseController
+        def update
+          find_or_initialize_vote.then do |vote|
+            if comment.children.where(user_id: current_user.id).exists?
+              handle_vote(vote)
+            else
+              render json: build_response(:rejected).
+                merge(info: t(".comment_before_downvote")),
+                status: :forbidden
+            end
+          end
+        end
+
+        private
+
+        def handle_vote(vote)
+          if vote.persisted?
+            handle_existing_vote(vote)
+          else
+            handle_downvote(vote)
+          end
+        end
+
+        def handle_existing_vote(vote)
+          if vote.downvote?
+            vote.destroy!
+            render json: build_response(:removed), status: :ok
+          else
+            handle_downvote(vote)
+          end
+        end
+
+        def handle_downvote(vote)
+          vote.downvote!
+          render json: build_response(:downvoted), status: :ok
+        end
+
+        def build_response(action)
+          {
+            short_id: params[:comment_short_id],
+            action: action
+          }
+        end
+
+        def comment
+          @_comment ||= Comment.friendly.find(params[:comment_short_id])
+        end
+
+        def find_or_initialize_vote
+          current_user.votes.comment.find_or_initialize_by(votable_id: comment.id)
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/comments/upvotes_controller.rb
+++ b/app/controllers/api/v1/comments/upvotes_controller.rb
@@ -1,0 +1,47 @@
+module Api
+  module V1
+    module Comments
+      class UpvotesController < BaseController
+        def update
+          find_or_initialize_vote.then do |vote|
+            if vote.persisted?
+              handle_existing_vote(vote)
+            else
+              handle_upvote(vote)
+            end
+          end
+        end
+
+        private
+
+        def handle_existing_vote(vote)
+          if vote.upvote?
+            vote.destroy!
+            render json: build_response(:removed), status: :ok
+          else
+            handle_upvote(vote)
+          end
+        end
+
+        def handle_upvote(vote)
+          vote.upvote!
+          render json: build_response(:upvoted), status: :ok
+        end
+
+        def build_response(action)
+          {
+            short_id: params[:comment_short_id],
+            action: action
+          }
+        end
+
+        def find_or_initialize_vote
+          comment = Comment.friendly.find(params[:comment_short_id])
+          current_user.votes.comment.find_or_initialize_by(votable_id: comment.id)
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/submissions/downvotes_controller.rb
+++ b/app/controllers/api/v1/submissions/downvotes_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V1
+    module Submissions
+      class DownvotesController < BaseController
+        def update
+          find_or_initialize_vote.then do |vote|
+            if current_user.comments.where(submission_id: submission.id, parent_id: nil).exists?
+              handle_vote(vote)
+            else
+              render json: build_response(:rejected).
+                merge(info: t(".comment_before_downvote")),
+                status: :forbidden
+            end
+          end
+        end
+
+        private
+
+        def handle_vote(vote)
+          if vote.persisted?
+            handle_existing_vote(vote)
+          else
+            handle_downvote(vote)
+          end
+        end
+
+        def handle_existing_vote(vote)
+          if vote.downvote?
+            vote.destroy!
+            render json: build_response(:removed), status: :ok
+          else
+            handle_downvote(vote)
+          end
+        end
+
+        def handle_downvote(vote)
+          vote.downvote!
+          render json: build_response(:downvoted), status: :ok
+        end
+
+        def build_response(action)
+          {
+            short_id: params[:submission_short_id],
+            action: action
+          }
+        end
+
+        def submission
+          @_submission ||= Submission.friendly.find(params[:submission_short_id])
+        end
+
+        def find_or_initialize_vote
+          current_user.votes.submission.find_or_initialize_by(votable_id: submission.id)
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/submissions/upvotes_controller.rb
+++ b/app/controllers/api/v1/submissions/upvotes_controller.rb
@@ -1,0 +1,47 @@
+module Api
+  module V1
+    module Submissions
+      class UpvotesController < BaseController
+        def update
+          find_or_initialize_vote.then do |vote|
+            if vote.persisted?
+              handle_existing_vote(vote)
+            else
+              handle_upvote(vote)
+            end
+          end
+        end
+
+        private
+
+        def handle_existing_vote(vote)
+          if vote.upvote?
+            vote.destroy!
+            render json: build_response(:removed), status: :ok
+          else
+            handle_upvote(vote)
+          end
+        end
+
+        def handle_upvote(vote)
+          vote.upvote!
+          render json: build_response(:upvoted), status: :ok
+        end
+
+        def build_response(action)
+          {
+            short_id: params[:submission_short_id],
+            action: action
+          }
+        end
+
+        def find_or_initialize_vote
+          submission = Submission.friendly.find(params[:submission_short_id])
+          current_user.votes.submission.find_or_initialize_by(votable_id: submission.id)
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -14,6 +16,7 @@ class User < ApplicationRecord
   has_many :submissions
   has_many :submission_actions
   has_many :comments
+  has_many :votes
 
   validates :username, presence: true
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -10,6 +10,9 @@ class Vote < ApplicationRecord
     downvote: 1
   }
 
+  scope :submission, -> { where(votable_type: "Submission") }
+  scope :comment, -> { where(votable_type: "Comment") }
+
   SUPPORTED_VOTABLE_TYPES = [Submission, Comment].freeze
 
   private

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -1,4 +1,10 @@
 en:
+  api:
+    v1:
+      comments:
+        downvotes:
+          update:
+            comment_before_downvote: "You must submit a response comment before you downvote a comment."
   comments:
     comment:
       link: link

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -1,4 +1,10 @@
 en:
+  api:
+    v1:
+      submissions:
+        downvotes:
+          update:
+            comment_before_downvote: "You must submit a response comment before you downvote a submission."
   submissions:
     submission_list_item:
       submitted_by: via 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,18 @@ Rails.application.routes.draw do
   namespace :users do
     resource :submission_actions, only: [:update]
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :comments, only: [], param: :short_id do
+        put :upvotes, action: :update, controller: "comments/upvotes"
+        put :downvotes, action: :update, controller: "comments/downvotes"
+      end
+
+      resources :submissions, only: [], param: :short_id do
+        put :upvotes, action: :update, controller: "submissions/upvotes"
+        put :downvotes, action: :update, controller: "submissions/downvotes"
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/comments/downvotes_spec.rb
+++ b/spec/requests/api/v1/comments/downvotes_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe "downvote comments" do
+  describe "PUT /api/v1/comments/:comment_short_id/downvotes" do
+    let(:comment) { create(:comment) }
+    let(:user) { create(:user) }
+
+    context "when the user is not logged in" do
+      it "returns 403 forbidden" do
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "when the user hasn't directly responded to the comment being downvoted" do
+      it "returns 403 forbidden and error information" do
+        login_as(user)
+        # some comment in response to the comment being downvoted but not made
+        # by our user
+        direct_comment = create(:comment, parent: comment, submission: comment.submission)
+        # i.e. the user has responded to a comment in the tree, but not the comment itself
+        # so they shouldn't be able to downvote.
+        user_response = create(
+          :comment,
+          parent: direct_comment,
+          submission: comment.submission,
+          user: user
+        )
+
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_forbidden
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "rejected",
+          info: I18n.t("api.v1.comments.downvotes.update.comment_before_downvote")
+        })
+      end
+    end
+
+    context "when no vote record exists for the user and comment" do
+      it "creates a new downvote vote record for the user and comment and returns 200" do
+        login_as(user)
+        create(:comment, parent: comment, user: user)
+
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "downvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Comment")
+        expect(vote.votable_id).to eq(comment.id)
+      end
+    end
+
+    # this corresponds with the user clicking the downvote button twice, i.e. to remove
+    # their vote.
+    context "when a vote record exists for the user and comment and it's an downvote" do
+      it "destroys it and returns a 200 status code" do
+        login_as(user)
+        create(:comment, parent: comment, user: user)
+        create(:downvote, votable: comment, user: user)
+
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "removed"
+        })
+        expect(Vote.count).to eq(0)
+      end
+    end
+
+    context "when a vote record exists for the user and comment and it's a downvote" do
+      it "turns it into an downvote and returns a 200 status code" do
+        login_as(user)
+        create(:comment, parent: comment, user: user)
+        create(:upvote, votable: comment, user: user)
+
+        put "/api/v1/comments/#{comment.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "downvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Comment")
+        expect(vote.votable_id).to eq(comment.id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/comments/upvotes_spec.rb
+++ b/spec/requests/api/v1/comments/upvotes_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe "upvote comments" do
+  describe "PUT /api/v1/comments/:comment_short_id/upvotes" do
+    let(:comment) { create(:comment) }
+    let(:user) { create(:user) }
+
+    context "when the user is not logged in" do
+      it "returns 403 forbidden" do
+        put "/api/v1/comments/#{comment.short_id}/upvotes"
+
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "when no vote record exists for the user and comment" do
+      it "creates a new upvote vote record for the user and comment and returns 200" do
+        login_as(user)
+
+        put "/api/v1/comments/#{comment.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "upvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Comment")
+        expect(vote.votable_id).to eq(comment.id)
+      end
+    end
+
+    # this corresponds with the user clicking the upvote button twice, i.e. to remove
+    # their vote.
+    context "when a vote record exists for the user and comment and it's an upvote" do
+      it "destroys it and returns a 200 status code" do
+        login_as(user)
+        create(:upvote, votable: comment, user: user)
+
+        put "/api/v1/comments/#{comment.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "removed"
+        })
+        expect(Vote.count).to eq(0)
+      end
+    end
+
+    context "when a vote record exists for the user and comment and it's a downvote" do
+      it "turns it into an upvote and returns a 200 status code" do
+        login_as(user)
+        create(:downvote, votable: comment, user: user)
+
+        put "/api/v1/comments/#{comment.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: comment.short_id,
+          action: "upvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Comment")
+        expect(vote.votable_id).to eq(comment.id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/submissions/downvotes_spec.rb
+++ b/spec/requests/api/v1/submissions/downvotes_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe "downvote submissions" do
+  describe "PUT /api/v1/submissions/:submission_short_id/downvotes" do
+    let(:submission) { create(:submission) }
+    let(:user) { create(:user) }
+
+    context "when the user is not logged in" do
+      it "returns 403 forbidden" do
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "when the user hasn't commented directly on the submission" do
+      it "returns 403 forbidden and error information" do
+        login_as(user)
+
+        # some comment in response to the comment being downvoted but not made
+        # by our user
+        direct_comment = create(:comment, submission: submission)
+        # i.e. the user has responded to a comment in the tree, but not the comment itself
+        # so they shouldn't be able to downvote. 
+        user_response = create(
+          :comment,
+          parent: direct_comment,
+          submission: submission,
+          user: user
+        )
+
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_forbidden
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "rejected",
+          info: I18n.t("api.v1.submissions.downvotes.update.comment_before_downvote")
+        })
+      end
+    end
+
+    context "when no vote record exists for the user and submission" do
+      it "creates a new downvote vote record for the user and submission and returns 200" do
+        login_as(user)
+        create(:comment, submission: submission, user: user)
+
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "downvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Submission")
+        expect(vote.votable_id).to eq(submission.id)
+      end
+    end
+
+    # this corresponds with the user clicking the downvote button twice, i.e. to remove
+    # their vote.
+    context "when a vote record exists for the user and submission and it's an downvote" do
+      it "destroys it and returns a 200 status code" do
+        login_as(user)
+        create(:comment, submission: submission, user: user)
+        create(:downvote, votable: submission, user: user)
+
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "removed"
+        })
+        expect(Vote.count).to eq(0)
+      end
+    end
+
+    context "when a vote record exists for the user and submission and it's a downvote" do
+      it "turns it into an downvote and returns a 200 status code" do
+        login_as(user)
+        create(:comment, submission: submission, user: user)
+        create(:upvote, votable: submission, user: user)
+
+        put "/api/v1/submissions/#{submission.short_id}/downvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "downvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Submission")
+        expect(vote.votable_id).to eq(submission.id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/submissions/upvotes_spec.rb
+++ b/spec/requests/api/v1/submissions/upvotes_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe "upvote submissions" do
+  describe "PUT /api/v1/submissions/:submission_short_id/upvotes" do
+    let(:submission) { create(:submission) }
+    let(:user) { create(:user) }
+
+    context "when the user is not logged in" do
+      it "returns 403 forbidden" do
+        put "/api/v1/submissions/#{submission.short_id}/upvotes"
+
+        expect(response).to be_forbidden
+      end
+    end
+
+    context "when no vote record exists for the user and submission" do
+      it "creates a new upvote vote record for the user and submission and returns 200" do
+        login_as(user)
+
+        put "/api/v1/submissions/#{submission.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "upvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Submission")
+        expect(vote.votable_id).to eq(submission.id)
+      end
+    end
+
+    # this corresponds with the user clicking the upvote button twice, i.e. to remove
+    # their vote.
+    context "when a vote record exists for the user and submission and it's an upvote" do
+      it "destroys it and returns a 200 status code" do
+        login_as(user)
+        create(:upvote, votable: submission, user: user)
+
+        put "/api/v1/submissions/#{submission.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "removed"
+        })
+        expect(Vote.count).to eq(0)
+      end
+    end
+
+    context "when a vote record exists for the user and submission and it's a downvote" do
+      it "turns it into an upvote and returns a 200 status code" do
+        login_as(user)
+        create(:downvote, votable: submission, user: user)
+
+        put "/api/v1/submissions/#{submission.short_id}/upvotes"
+
+        body = JSON.parse(response.body).symbolize_keys
+
+        expect(response).to be_ok
+        expect(body).to eq({
+          short_id: submission.short_id,
+          action: "upvoted"
+        })
+        expect(Vote.count).to eq(1)
+
+        vote = Vote.first
+
+        expect(vote.user_id).to eq(user.id)
+        expect(vote.votable_type).to eq("Submission")
+        expect(vote.votable_id).to eq(submission.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/w9pQI5lQ
https://trello.com/c/FiwnyH46
https://trello.com/c/DD0nQfG3
https://trello.com/c/Pb08HQGH

this commit adds in the relevant upvote and downvote APIs
  for submissions and comments. The views will be hooked into
  them in a subsequent commit.

I opted to go with separate API endpoints rather than a single
  voting endpoint to avoid having to introduce additional logic
  to deal with an incoming vote request.

Plus, if for example, a request is made to the comment upvotes
  endpoint, we know for a fact that:

  - it is a request relating to a comment
  - it is some form of request relating to an upvote

Contrast this with if we had a single vote API (or even a vote
  API for each votable type), where we would have to include
  additional information in the request to try to tell the controller
  how to handle the request.

Under the scheme I've implemented, the only information that we need
  is the short id for the resource (and the currently logged in user).