### PR TITLE
adds configurations for mailing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,6 @@
 # raise exceptions when I18n translations are missing; useful for development + testing
 RAISE_ON_MISSING_TRANSLATIONS=TRUE
+SMTP_SENDER_EMAIL=foo@bar.com
+SMTP_ADDRESS=smtp.domain.com
+SMTP_USERNAME=foop
+SMTP_PASSWORD=foobar

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,8 +21,12 @@ class User < ApplicationRecord
   validates :username, presence: true
 
   def self.find_first_by_auth_conditions(warden_conditions)
-    warden_conditions.fetch(:username, nil).then do |username|
-      where("lower(username) = ?", username.downcase).first if username.present?
+    if warden_conditions.key?(:confirmation_token)
+      super
+    else
+      warden_conditions.fetch(:username, nil).then do |username|
+        where("lower(username) = ?", username.downcase).first if username.present?
+      end
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+require Rails.root.join('config/smtp')
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -56,6 +57,9 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "simple_group_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST"), protocol: "https" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV.fetch("SMTP_SENDER_EMAIL")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/smtp.rb
+++ b/config/smtp.rb
@@ -1,0 +1,8 @@
+SMTP_SETTINGS = {
+  address: ENV.fetch('SMTP_ADDRESS'),
+  authentication: :login,
+  enable_starttls_auto: true,
+  password: ENV.fetch('SMTP_PASSWORD'),
+  port: '587',
+  user_name: ENV.fetch('SMTP_USERNAME')
+}.freeze


### PR DESCRIPTION
We need to be able to mail stuff to folks for
  things like email confirmations.

This enables us to do that.

I've set us up with Amazon SES for use in production.

At the moment I just have it using my own domain, but once
  we have an actual domain I'll configure it for that.