### PR TITLE
flash polish

### DIFF
--- a/app/assets/stylesheets/base/_flash.scss
+++ b/app/assets/stylesheets/base/_flash.scss
@@ -1,22 +1,31 @@
-.flash-message {
-    cursor: pointer;
+#flash-container {
+    position: fixed;
+    top: 2rem;
+    left: 50%;
+    z-index: 1;
+
+    p {
+        display: inline;
+        margin: 0;
+    }
+
     .flash {
-        position: fixed;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        cursor: pointer;
         padding: $spacing-small;
         background-color: $white;
         box-shadow: $box-shadow;
-        top: 2rem;
-        left: 50%;
         transform: translateX(-50%);
         font-weight: normal;
+        text-align: center;
+        align-items: center;
+        margin-bottom: $spacing-small;
+
         .flash-close {
+            margin-left: $spacing-smaller;
             font-family: $font-stack-mono;
             color: lighten($scorpion, 20%);
-            margin-left: $spacing-small;
         }
-    }
-    input[type="checkbox"],
-    :checked + .flash {
-        display: none;
     }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,3 +14,17 @@ require("@rails/activestorage").start()
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+
+const pageload = require("./pageload");
+
+pageload.onPageLoad(function() {
+  let flash_container = document.getElementById("flash-container");
+  for(let child=flash_container.firstChild; child!==null; child=child.nextSibling) {
+    child.addEventListener("click", function() {
+        child.remove();
+    });
+    setTimeout(function(){ 
+        child.remove();
+    }, 10000);
+  };
+});

--- a/app/javascript/packs/flash.js
+++ b/app/javascript/packs/flash.js
@@ -1,19 +1,25 @@
 function createFlash(flashType, message) {
-  let flashBase = document.createElement("label")
-  flashBase.classList.add("flash-message");
-  let flashCheck = document.createElement("input");
-  flashCheck.type = "checkbox";
-  flashBase.appendChild(flashCheck);
-  let flashMsgDiv = document.createElement("div");
+
+  let flashBase = document.createElement("div")
+  flashBase.classList.add("flash");
+  flashBase.classList.add("flash-" + flashType);
+
+  let flashMsg = document.createElement("p");
+  flashMsg.innerHTML = message;
+  flashBase.appendChild(flashMsg);
+
   let flashClose = document.createElement("span");
-  flashMsgDiv.classList.add("flash");
-  flashMsgDiv.classList.add("flash-" + flashType);
   flashClose.classList.add("flash-close");
   flashClose.appendChild(document.createTextNode("x"));
-  flashMsgDiv.appendChild(document.createTextNode(message));
-  flashMsgDiv.appendChild(flashClose);
-  flashBase.appendChild(flashMsgDiv);
+  flashBase.appendChild(flashClose);
+
   document.getElementById("flash-container").appendChild(flashBase);
+  flashBase.addEventListener("click", function() {
+      flashBase.remove();
+  });
+  setTimeout(function(){ 
+      flashBase.remove();
+  }, 10000);
 }
 
 export function flashAlert(message) {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,10 +14,8 @@
     = render "layouts/navbar"
     #flash-container
       - flash.each do |flash_type, flash_message|
-        %label.flash-message
-          %input{ type: "checkbox" }
-          .flash{ class: "flash-#{flash_type}" }
-            = flash_message
-            %span.flash-close x
+        .flash{ class: "flash-#{flash_type}" }
+          %p= flash_message
+          %span.flash-close x
     .application-container
       = yield


### PR DESCRIPTION
This is a small PR that changes the flash frontend a bit.

- Flashes are less buggy in CSS:
    - Multiple flashes stack properly
    - "x" stays in right(or left, really) place on smaller screens
    - Flashes properly float on top of latex
- Now using JS instead of  the hacky input/checkbox workaround for closing the flashes
    - Simpler HTML/CSS
    - A bit more complicated javascipt (but now timeouts actually exist!)