### PR TITLE
polishing of `new submission` page

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -3,7 +3,7 @@ button,
 [type="reset"],
 [type="submit"] {
   appearance: none;
-  background-color: $action-color;
+  background-color: $blue-medium;
   border: 0;
   border-radius: $border-radius;
   color: $white;
@@ -25,7 +25,7 @@ button,
   margin: 0.5rem 0;
 
   &:hover {
-    background-color: $action-color--alt;
+    background-color: lighten($blue-medium, 10%);
   }
 
   &:focus:not(:hover) {
@@ -42,6 +42,6 @@ button,
   }
 
   &:active {
-    background-color: darken($action-color, 10%);
+    background-color: darken($blue-medium, 10%);
   }
 }

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -104,6 +104,8 @@ textarea {
 [type="radio"],
 [type="file"],
 select {
+  background-color: $white-gray;
+
   &:focus:not(:hover) {
     outline: $focus-outline;
   }

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -1,6 +1,7 @@
 // Colors
 $alto: #cecece;
 $blue: #1565c0;
+$blue-medium: #0e7ab6;
 $blue-light: #3b83d5;
 $blue-light-very: #f4fbff;
 $congress-blue: #004e98;

--- a/app/assets/stylesheets/shared/_simple_form.scss
+++ b/app/assets/stylesheets/shared/_simple_form.scss
@@ -4,4 +4,27 @@ form {
     @include margin(null null $spacing-smaller null);
     display: block;
   }
+
+  .error {
+      color: $red;
+  }
+  #type-selector {
+      margin: $spacing-xs 0 $spacing-small 0;
+
+     [type="radio"] {
+       display: none;
+     }
+
+     label {
+         border-bottom: 2px solid lighten($scorpion, 20%);
+         padding: $spacing-xs;
+         font-size: 105%;
+         color: lighten($scorpion, 20%);
+     }
+
+     [type="radio"]:checked + label {
+         color: $action-color--alt;
+         border-color: $font-color--base;
+     }
+  }
 }

--- a/app/javascript/packs/submission_new.js
+++ b/app/javascript/packs/submission_new.js
@@ -1,0 +1,26 @@
+const pageload = require("./pageload");
+
+pageload.onPageLoad(function() {
+    console.log("loaded");
+    let link = document.getElementById("link");
+    let text = document.getElementById("text");
+    let url_wrapper = document.getElementById("url_wrapper");
+    let body_wrapper = document.getElementById("body_wrapper");
+    url_wrapper.lastChild.toggleAttribute("required");
+    link.addEventListener('change', function() {
+        url_wrapper.style.display = "initial";
+        url_wrapper.lastChild.toggleAttribute("disabled");
+        url_wrapper.lastChild.toggleAttribute("required");
+        body_wrapper.style.display = "none";
+        body_wrapper.lastChild.toggleAttribute("disabled");
+        body_wrapper.lastChild.toggleAttribute("required");
+    });
+    text.addEventListener('change', function() {
+        body_wrapper.style.display = "initial";
+        body_wrapper.lastChild.toggleAttribute("disabled");
+        body_wrapper.lastChild.toggleAttribute("required");
+        url_wrapper.style.display = "none";
+        url_wrapper.lastChild.toggleAttribute("disabled");
+        url_wrapper.lastChild.toggleAttribute("required");
+    });
+});

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,14 +1,26 @@
+- content_for :page_styles do
+  = javascript_pack_tag "submission_new"
 %h2.prompt= t(".title")
-%ul.errors
-  - @form.errors.values.flatten.map do |e|
-    %li.error= e
 = simple_form_for @form, url: submissions_path do |f|
-  = f.input :url
-  = f.input :title
+  = f.input :title, input_html: { minlength: 10, maxlength: 175 }
   = f.input :tag_ids, collection: tag_select_options(current_user),
     input_html: { multiple: true, id: "tag-select" }
-  = f.input :body, as: :text, input_html: { rows: 15 }
+  %label= t(".submission_type")
+  #type-selector
+    %input{ type: "radio", id: "link", name: "option", checked: "checked" }
+    %label{ for: "link" }= t(".link_type")
+    %input{ type: "radio", id: "text", name: "option" }
+    %label{ for: "text" }= t(".text_type")
+  = f.input :url, wrapper_html: { id: "url_wrapper" }
+  = f.input :body, as: :text, input_html: { rows: 15, disabled: "disabled" },
+    wrapper_html: { style: "display:none;", id: "body_wrapper" }
   .original-author-statement
     = f.input :original_author, as: :boolean, wrapper: :left_hand_label
     = t(".original_author")
   = f.button :button, type: :submit
+  - if @form.errors.messages.key?(:user)
+    %span.error= @form.errors.messages[:user].join("")
+  - if @form.errors.messages.key?(:base)
+    %span.error= @form.errors.messages[:base].join("")
+  - if @form.errors.messages.key?(:domain)
+    %span.error= @form.errors.messages[:domain].join("")

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -112,7 +112,7 @@ SimpleForm.setup do |config|
   # config.item_wrapper_class = nil
 
   # How the label text should be generated altogether with the required text.
-  config.label_text = lambda { |label, required, explicit_label| "#{required}#{label}" }
+  config.label_text = lambda { |label, required, explicit_label| "#{label}" }
 
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil
@@ -132,7 +132,7 @@ SimpleForm.setup do |config|
   # in this configuration, which is recommended due to some quirks from different browsers.
   # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
   # change this configuration to true.
-  config.browser_validations = false
+  config.browser_validations = true
 
   # Custom mappings for input types. This should be a hash containing a regexp
   # to match as key, and the input type that will be used when the field name

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -19,8 +19,11 @@ en:
           saved: save
       comments: "%{count} comments"
     new:
-      title: Make a new submission
+      title: New submission
       original_author: I am the original author of this content.
+      submission_type: Type
+      link_type: LINK
+      text_type: TEXT
       error:
         banned_domain: "The submission is from a banned domain: %{domain}"
         title_missing: Please ensure you provide a helpful title between 10 and 175 characters long.

--- a/spec/support/page_objects/create_submission_page.rb
+++ b/spec/support/page_objects/create_submission_page.rb
@@ -22,6 +22,20 @@ class CreateSubmissionPage < PageBase
     self
   end
 
+  def click_link_tab
+    within("div#type-selector") do
+      find("label", text: t("submissions.new.link_type")).click
+    end
+    self
+  end
+
+  def click_text_tab
+    within("div#type-selector") do
+      find("label", text: t("submissions.new.text_type")).click
+    end
+    self
+  end
+
   def fill_in_body(str)
     fill_in :create_submission_form_body, with: str
     self
@@ -39,12 +53,27 @@ class CreateSubmissionPage < PageBase
     self
   end
 
-  def has_title_missing_error?
-    has_error?(t("submissions.new.error.title_missing"))
+  def has_submission_body_text_box?
+    has_css?("#body_wrapper", visible: true)
   end
 
-  def has_title_length_error?
-    has_error?(t("submissions.new.error.title_length"))
+  def has_submission_url_text_box?
+    has_css?("#url_wrapper", visible: true)
+  end
+
+  def has_title_missing_error?
+    has_client_side_error?("#create_submission_form_title", "Please fill out this field.")
+  end
+
+  def has_title_too_short_error?(char_num)
+    has_client_side_error?(
+      "#create_submission_form_title",
+      "Please lengthen this text to 10 characters or more (you are currently using #{char_num} characters)."
+    )
+  end
+
+  def has_title_with_x_chars?(char_num)
+    page.find("#create_submission_form_title").value.length == char_num
   end
 
   def has_url_xor_body_error?
@@ -52,7 +81,7 @@ class CreateSubmissionPage < PageBase
   end
 
   def has_missing_tags_error?
-    has_error?(t("submissions.new.error.tags_missing"))
+    has_client_side_error?("#tag-select", "Please select an item in the list.")
   end
 
   def has_tags_max_error?
@@ -88,8 +117,12 @@ class CreateSubmissionPage < PageBase
   end
 
   def has_error?(error)
-    within find(".errors") do
-      has_css?("li.error", text: error)
+    within("form#new_create_submission_form") do
+      has_css?("span.error", text: error)
     end
+  end
+
+  def has_client_side_error?(field, message)
+    page.find(field).native.attribute("validationMessage") == message
   end
 end


### PR DESCRIPTION
Makes the new submission page have a tabbed structure for body/URL, which makes it clearer that you only need one. I'd attach a gif but I haven't figured out how to do that on Linux + Wayland yet. I'm not 100% satisfied with the CSS yet.

My wishlist for this:
 - Remove all `*` stars that indicate field requirement, since they aren't really necessary for clarity anymore with this tabbed structure(all visible fields are required), and are just clutter.
 - Save state on error - right now currently selected tab, as well as information in other tab, is lost on error because all of that is client-side. This can be somewhat mitigated by introducing client-side HTML5 form validations as well, but it wouldn't solve the issue.

I am not certain how to accomplish the above two tasks, hence this WIP PR.