### PR TITLE
allows users to cancel their accounts

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -29,6 +29,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def destroy
+    UserRemovalService.new(current_user).remove
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message! :notice, :destroyed
+    redirect_to root_path
+  end
+
   protected
 
   def configure_sign_up_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  def create
+    if sign_in_params[:username].downcase == User::DELETED
+      redirect_to new_user_session_path
+    else
+      super
+    end
+  end
 end

--- a/app/services/user_removal_service.rb
+++ b/app/services/user_removal_service.rb
@@ -1,0 +1,55 @@
+class UserRemovalService
+  def initialize(user)
+    @user = user
+  end
+
+  def remove
+    ApplicationRecord.transaction do
+      remove_submission_data
+      remove_comment_data
+      remove_invitation_data
+      deactivate_user
+    end
+  end
+
+  private
+
+  # rubocop:disable Rails/SkipsModelValidations
+
+  def remove_submission_data
+    user.submissions.where(url: nil).update_all(body: User::DELETED)
+  end
+
+  def remove_comment_data
+    user.comments.update_all(body: User::DELETED)
+  end
+
+  def remove_invitation_data
+    user.received_user_invitation&.update_column(:recipient_email, User::DELETED)
+  end
+
+  def deactivate_user
+    password = SecureRandom.uuid
+
+    user.update!(
+      password: password,
+      password_confirmation: password
+    )
+
+    user.update_columns(
+      email: User::DELETED,
+      confirmation_token: nil,
+      confirmed_at: nil,
+      confirmation_sent_at: nil,
+      unconfirmed_email: User::DELETED,
+      unlock_token: nil,
+      locked_at: Time.zone.now,
+      role: :deactivated,
+      username: User::DELETED
+    )
+  end
+
+  # rubocop:enable Rails/SkipsModelValidations
+
+  attr_reader :user
+end

--- a/db/migrate/20200823183710_change_uniqueness_indexes_on_users_to_exclude_deleted.rb
+++ b/db/migrate/20200823183710_change_uniqueness_indexes_on_users_to_exclude_deleted.rb
@@ -1,0 +1,19 @@
+class ChangeUniquenessIndexesOnUsersToExcludeDeleted < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :users, name: "index_users_on_LOWER_email"
+    remove_index :users, name: "index_users_on_LOWER_username"
+
+    add_index :users, "LOWER(email)", unique: true, name: "index_users_on_LOWER_email",
+      where: "LOWER(email) != '[deleted]'"
+    add_index :users, "LOWER(username)", unique: true, name: "index_users_on_LOWER_username",
+      where: "LOWER(username) != '[deleted]'"
+  end
+
+  def down
+    remove_index :users, name: "index_users_on_LOWER_email"
+    remove_index :users, name: "index_users_on_LOWER_username"
+
+    add_index :users, "LOWER(email)", unique: true, name: "index_users_on_LOWER_email"
+    add_index :users, "LOWER(username)", unique: true, name: "index_users_on_LOWER_username"
+  end
+end

--- a/db/migrate/20200823184606_change_unique_index_on_user_invitations.rb
+++ b/db/migrate/20200823184606_change_unique_index_on_user_invitations.rb
@@ -1,0 +1,13 @@
+class ChangeUniqueIndexOnUserInvitations < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :user_invitations, :recipient_email
+    add_index :user_invitations, "LOWER(recipient_email)",
+      unique: true, name: "index_user_invitations_on_LOWER_recipient_email",
+      where: "LOWER(recipient_email) != '[deleted]'"
+  end
+
+  def down
+    remove_index :user_invitations, name: "index_user_invitations_on_LOWER_recipient_email"
+    add_index :user_invitations, :recipient_email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_06_160510) do
+ActiveRecord::Schema.define(version: 2020_08_23_184606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2020_06_06_160510) do
     t.string "token", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["recipient_email"], name: "index_user_invitations_on_recipient_email", unique: true
+    t.index "lower((recipient_email)::text)", name: "index_user_invitations_on_LOWER_recipient_email", unique: true, where: "(lower((recipient_email)::text) <> '[deleted]'::text)"
     t.index ["recipient_id"], name: "index_user_invitations_on_recipient_id"
     t.index ["sender_id"], name: "index_user_invitations_on_sender_id"
     t.index ["token"], name: "index_user_invitations_on_token", unique: true
@@ -119,8 +119,8 @@ ActiveRecord::Schema.define(version: 2020_06_06_160510) do
     t.integer "role", default: 0, null: false
     t.string "username", limit: 20, null: false
     t.datetime "last_submission_at"
-    t.index "lower((email)::text)", name: "index_users_on_LOWER_email", unique: true
-    t.index "lower((username)::text)", name: "index_users_on_LOWER_username", unique: true
+    t.index "lower((email)::text)", name: "index_users_on_LOWER_email", unique: true, where: "(lower((email)::text) <> '[deleted]'::text)"
+    t.index "lower((username)::text)", name: "index_users_on_LOWER_username", unique: true, where: "(lower((username)::text) <> '[deleted]'::text)"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role"], name: "index_users_on_role"

--- a/spec/factories/user_invitations.rb
+++ b/spec/factories/user_invitations.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     sent_at { Time.zone.now }
     accepted_at { nil }
     token { SecureRandom.uuid }
+
+    trait :accepted do
+      association :recipient, factory: :user
+      recipient_email { recipient.email }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
 
     trait(:admin) { role { :admin } }
     trait(:moderator) { role { :moderator } }
+    trait(:deactivated) { role { :deactivated } }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,15 @@
 RSpec.describe User do
-  it { should define_enum_for(:role).with_values(member: 0, moderator: 10, admin: 20) }
+  it { should define_enum_for(:role).with_values(member: 0, moderator: 10, admin: 20, deactivated: 100) }
   it { should have_many(:submissions) }
   it { should have_many(:submission_actions) }
   it { should have_many(:comments) }
+  it { should have_many(:votes) }
+  it { should have_many(:sent_user_invitations).class_name(:UserInvitation).with_foreign_key(:sender_id) }
+
+  it do
+    should have_one(:received_user_invitation).
+      class_name(:UserInvitation).with_foreign_key(:recipient_id).required(false)
+  end
 
   describe "#update_last_submission_at!" do
     it "updates the last submission time to the current time" do

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "User sessions" do
+  describe "POST /users/sign_in" do
+    context "when the username is `[deleted]`" do
+      it "doesn't even attempt a login and redirects to the sign in path" do
+        user = create(:user, password: "abcd1234")
+        # rubocop:disable Rails/SkipsModelValidations
+        user.update_column(:username, "[deleted]")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        post "/users/sign_in", params: {
+          user: {
+            username: "[deleted]",
+            password: "abcd1234"
+          }
+        }
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when the user is deactivated" do
+      it "renders the sign in page and says the login credentials are invalid" do
+        user = create(:user, :deactivated, password: "abcd1234")
+
+        post "/users/sign_in", params: {
+          user: {
+            username: user.username,
+            password: "abcd1234"
+          }
+        }
+
+        expect(response.body).to match("Invalid Username or password")
+      end
+    end
+  end
+end

--- a/spec/services/user_removal_service_spec.rb
+++ b/spec/services/user_removal_service_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe UserRemovalService do
+  describe "#remove" do
+    it "scrubs the user data, sets their username / email to `[deleted]`, and changes status to deactivated" do
+      user = create(:user)
+      tag = create(:topic_tag)
+      url_submission = create(:submission, :url, title: "foo title", url: "https://site.com", user: user, tags: [tag])
+      text_submission = create(:submission, :text, title: "bar title", body: "abcdefghijklmn", user: user, tags: [tag])
+      comment = create(:comment, user: user, body: "123456789")
+      create(:user_invitation, :accepted, recipient: user)
+
+      service = UserRemovalService.new(user)
+
+      service.remove
+
+      user.reload
+
+      expect(user).to be_deactivated
+      expect(user.email).to eq(User::DELETED)
+      expect(user.unconfirmed_email).to eq(User::DELETED)
+      expect(user.username).to eq(User::DELETED)
+      expect(user.confirmation_token).to be_nil
+      expect(user.confirmed_at).to be_nil
+      expect(user.confirmation_sent_at).to be_nil
+      expect(user.locked_at).to be_present
+
+      url_submission.reload
+      # we don't expect URL submissions to change
+      expect(url_submission.title).to eq("foo title")
+      expect(url_submission.url).to eq("https://site.com")
+
+      text_submission.reload
+      expect(text_submission.title).to eq("bar title")
+      expect(text_submission.body).to eq(User::DELETED)
+
+      comment.reload
+      expect(comment.body).to eq(User::DELETED)
+
+      expect(user.received_user_invitation.recipient_email).to eq(User::DELETED)
+    end
+  end
+end

--- a/spec/support/page_objects/user_edit_page.rb
+++ b/spec/support/page_objects/user_edit_page.rb
@@ -44,6 +44,13 @@ class UserEditPage < PageBase
     self
   end
 
+  def cancel_account
+    accept_confirm do
+      click_link t("users.registrations.edit.cancel_my_account")
+    end
+    self
+  end
+
   def has_update_needs_confirmation_notice?
     has_notice?(t("users.registrations.update_needs_confirmation"))
   end
@@ -72,5 +79,9 @@ class UserEditPage < PageBase
           has_css?("td", text: invite.accepted_at)
       end)
     end
+  end
+
+  def has_account_cancelled_notice?
+    has_notice?(t("users.registrations.destroyed"))
   end
 end

--- a/spec/support/page_objects/user_registration_page.rb
+++ b/spec/support/page_objects/user_registration_page.rb
@@ -35,4 +35,8 @@ class UserRegistrationPage < PageBase
   def has_missing_username_error?
     has_missing_field_error?(".user_username")
   end
+
+  def has_invalid_username_error?
+    has_invalid_field_error?(".user_username")
+  end
 end

--- a/spec/system/user_cancels_account_spec.rb
+++ b/spec/system/user_cancels_account_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "User cancels account", js: true do
+  it "scrubs all of their data and sets their username to [deleted], without impacting other user data" do
+    user = create(:user)
+    tag = create(:topic_tag)
+    url_submission = create(:submission, :url, title: "foo title", url: "https://site.com", user: user, tags: [tag])
+    text_submission = create(:submission, :text, title: "bar title", body: "abcdefghijklmn", user: user, tags: [tag])
+    comment = create(:comment, user: user, body: "123456789")
+    create(:user_invitation, :accepted, recipient: user)
+
+    page = UserEditPage.new
+
+    page.visit(as: user)
+
+    page.cancel_account
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_account_cancelled_notice
+
+    user.reload
+
+    expect(user).to be_deactivated
+    expect(user.email).to eq(User::DELETED)
+    expect(user.unconfirmed_email).to eq(User::DELETED)
+    expect(user.username).to eq(User::DELETED)
+    expect(user.confirmation_token).to be_nil
+    expect(user.confirmed_at).to be_nil
+    expect(user.confirmation_sent_at).to be_nil
+    expect(user.locked_at).to be_present
+
+    url_submission.reload
+    # we don't expect URL submissions to change
+    expect(url_submission.title).to eq("foo title")
+    expect(url_submission.url).to eq("https://site.com")
+
+    text_submission.reload
+    expect(text_submission.title).to eq("bar title")
+    expect(text_submission.body).to eq(User::DELETED)
+
+    comment.reload
+    expect(comment.body).to eq(User::DELETED)
+
+    expect(user.received_user_invitation.recipient_email).to eq(User::DELETED)
+  end
+end

--- a/spec/system/user_registration_spec.rb
+++ b/spec/system/user_registration_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe "user fills out registration form" do
           expect(page).to have_missing_password_error
         end
       end
+
+      context "when the user tries to signup with a forbidden username" do
+        it "tells the user that the username is invalid" do
+          page.visit.fill_out_form({
+            username: User::DELETED,
+            email: "foobar@baz.com",
+            password: "abcd1234",
+            password_confirmation: "abcd1234"
+          }).submit_form
+
+          expect(page).to have_invalid_username_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/Yhd01aZw

This commit adds functionality for users to cancel their accounts
  and *mostly* remove their data. The strategy is as follows:

- all references to username / email are set to `[deleted]`, including:
  - account email
  - unconfirmed emails
  - the email on their original invitation to the site if it exists

- all submission text / comment bodies are set to `[deleted]`

- account password is set to a secure random uuid

- account role is set to `deactivated`

The intent is to maintain the integrity of our data (so that we don't do
  things like mess up the invite tree, comment trees, screw up user
  karma, etc), while also giving users the ability to more or less scrub
  themselves from our site.

We don't keep a lot of personally identifying information at present, so
  things are pretty straightforward thus far. In the future, when we
  allow users to do things like share their contact information (i.e.
  social media profiles, githubs, etc.) we can just change the removal
  service to scrub those as well.

I did not do anything relating to submission titles / URL submissions,
  the rationale being:

- titles (in the future) can be auto-generated given a link
  - also, a submission title being used as a personally identifiable
    piece of information is questionable at best, in general

- URLs are on the internet regardless, and so public

On top of the above, we introduce the following behaviors:

- signups with the username `[deleted]` are not allowed

- attempting to signin as `[deleted]` will not even entertain an auth
  request, it will just redirect to the signin page

- attempting to signin as a deactivated account will display an invalid
  credentials error